### PR TITLE
Se agregó la funcionalidad de que al hacer click en un elemento del side-bar se cambie lo que se muestra en la parte central de la página

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,4 @@
-{}
+{
+    "material-icon-theme.activeIconPack": "react",
+    "materialTheme.accent": "Orange"
+}

--- a/frontend/src/reunion/Reunion.js
+++ b/frontend/src/reunion/Reunion.js
@@ -1,30 +1,30 @@
 import React from 'react';
-import { Redirect } from 'react-router-dom';
 import Temario from '../temario/Temario';
 import Sidebar from '../sidebar-reunion/Sidebar';
 import { ReunionContainer } from './Reunion.styled';
-import { Button } from '../components/Button.styled';
-import backend from '../api/backend';
+import VistaActual from './VistaActual';
 
 class Reunion extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       redirect: false,
+      selectedElement: 'Tema Actual',
     };
   }
 
-  handleCerrarReunion = () => backend.cerrarReunion().then(() => this.setState({ redirect: true }));
+  handleSelection = (name) => {
+    this.setState({
+      selectedElement: name,
+    });
+  }
 
   render() {
-    if (this.state.redirect) return <Redirect to="/" />;
-
     return (
       <ReunionContainer>
         <Temario/>
-        Tema actual
-      <Button onClick={this.handleCerrarReunion}> Cerrar reunion </Button>
-      <Sidebar/>
+        <VistaActual vista={this.state.selectedElement}/>
+        <Sidebar handleSelection={this.handleSelection} selectedElement={this.state.selectedElement}/>
       </ReunionContainer>);
   }
 }

--- a/frontend/src/reunion/VistaActual.js
+++ b/frontend/src/reunion/VistaActual.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import backend from '../api/backend';
+import { Button } from '../components/Button.styled';
+import TemaActual from '../tipos-vista-principal/TemaActual';
+import Presentacion from '../tipos-vista-principal/Presentacion';
+import Analytics from '../tipos-vista-principal/Analytics';
+
+class VistaActual extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      redirect: false,
+      selectedElement: 'Tema Actual',
+    };
+  }
+
+    vistas = [TemaActual, Presentacion, Analytics]
+
+    handleCerrarReunion = () => backend.cerrarReunion().then(() => this.setState({ redirect: true }));
+
+    obtenerVista = () => this.vistas.find((vista) => vista.canHandleView(this.props.vista))
+
+    render() {
+      if (this.state.redirect) return <Redirect to="/" />;
+
+      return (
+           <div>
+               <Button onClick={this.handleCerrarReunion}>Cerrar Reunión</Button>
+               {this.obtenerVista().render()}
+           </div>
+      );
+    }
+}
+
+export default VistaActual;

--- a/frontend/src/sidebar-reunion/Sidebar.js
+++ b/frontend/src/sidebar-reunion/Sidebar.js
@@ -17,16 +17,10 @@ class Sidebar extends React.Component {
     { icon: faComment, title: 'Presentación' },
     { icon: faChartBar, title: 'Analytics' }];
 
-  handleSelection = (name) => {
-    this.setState({
-      selectedElement: name,
-    });
-  }
-
   render() {
     return (
         <SidebarContainer>
-          {this.menu.map((seccion) => <div onClick={() => this.handleSelection(seccion.title)}> <SidebarElement icon={seccion.icon} title={seccion.title} isActive={this.state.selectedElement === seccion.title}/> </div>)}
+          {this.menu.map((seccion) => <div onClick={() => this.props.handleSelection(seccion.title)}> <SidebarElement icon={seccion.icon} title={seccion.title} isActive={this.props.selectedElement === seccion.title}/> </div>)}
         </SidebarContainer>
     );
   }

--- a/frontend/src/tipos-vista-principal/Analytics.js
+++ b/frontend/src/tipos-vista-principal/Analytics.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class Analytics extends React.Component {
+    static canHandleView = (view) => view === 'Analytics'
+
+    static render() {
+      return (
+        <div>
+            Gráficos locos sólo para entendidos
+        </div>
+      );
+    }
+}
+
+export default Analytics;

--- a/frontend/src/tipos-vista-principal/Presentacion.js
+++ b/frontend/src/tipos-vista-principal/Presentacion.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class Presentacion extends React.Component {
+    static canHandleView = (view) => view === 'Presentación'
+
+    static render() {
+      return (
+        <div>
+            Acá ven preciosas slides de presentación
+        </div>
+      );
+    }
+}
+
+export default Presentacion;

--- a/frontend/src/tipos-vista-principal/TemaActual.js
+++ b/frontend/src/tipos-vista-principal/TemaActual.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class TemaActual extends React.Component {
+    static canHandleView = (view) => view === 'Tema Actual'
+
+    static render() {
+      return (
+        <div>
+            Si, este es un tema actual o de actualidad :P
+        </div>
+      );
+    }
+}
+
+export default TemaActual;


### PR DESCRIPTION
![Captura de pantalla de 2019-11-25 09-56-10](https://user-images.githubusercontent.com/11839350/69542292-e4a19980-0f69-11ea-9b49-9db9bbb55b06.png)
![Captura de pantalla de 2019-11-25 09-56-54](https://user-images.githubusercontent.com/11839350/69542310-eff4c500-0f69-11ea-873c-111f50f563a8.png)
![Captura de pantalla de 2019-11-25 09-57-14](https://user-images.githubusercontent.com/11839350/69542329-fd11b400-0f69-11ea-8f73-4a3faa9307f0.png)

A priori sólo se muestra un texto distinto según la selección realizada. Y no cambia la ruta de la página sino sólo lo renderizado, ya que al hablarlo con el PO nos comentó que por el momento para esta historia no tiene sentido y no sabe qué tanto vamos a querer que cambie la ruta según la vista, así que por el momento se deja así y si en el futuro se necesita, se agrega.

Con este PR estaría finalizada la story:
https://trello.com/c/uGzU9m6j/23-sidebar-de-selecci%C3%B3n-de-vistas-2
