### PR TITLE
agrego columna con duracion de tema a la tabla de temas de la bd de b…

### DIFF
--- a/backend/src/database/migrations/20191203145107-agregar-duracion-tema.js
+++ b/backend/src/database/migrations/20191203145107-agregar-duracion-tema.js
@@ -1,0 +1,12 @@
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn(
+    'Temas',
+    'cantidadDeMinutosDelTema',
+    {
+      type: Sequelize.INTEGER,
+    },
+  ),
+
+  down: (queryInterface, Sequelize) => queryInterface.removeColumn('Temas', 'cantidadDeMinutosDelTema'),
+};

--- a/backend/src/database/models/tema.js
+++ b/backend/src/database/models/tema.js
@@ -12,6 +12,7 @@ module.exports = (sequelize, DataTypes) => {
     temasParaRepasar: DataTypes.JSON,
     inicio: DataTypes.DATE,
     fin: DataTypes.DATE,
+    cantidadDeMinutosDelTema: DataTypes.INTEGER,
   }, {});
   Tema.associate = function (models) {
     Tema.Reunion = Tema.belongsTo(models.Reunion, {as: 'reunion'});

--- a/backend/src/domain/temas/repo.js
+++ b/backend/src/domain/temas/repo.js
@@ -20,7 +20,7 @@ export default class TemasRepo {
   guardarTemas(reunion, temas) {
     return models.Tema.bulkCreate(temas.map((tema) => {
       const temaSanitizado = pick(tema, ['tipo', 'titulo', 'descripcion', 'duracion', 'autor', 'obligatoriedad',
-        'linkDePresentacion', 'propuestas', 'temasParaRepasar']);
+        'linkDePresentacion', 'propuestas', 'temasParaRepasar', 'cantidadDeMinutosDelTema']);
 
       return { ...temaSanitizado, reunionId: reunion.id };
     }));


### PR DESCRIPTION
[**Link al Trello**](https://trello.com/c/2ZQFBcZ6/40-persistir-duraci%C3%B3n-de-tema-en-el-backend)

**Aceptación**
Se toma la duración de minutos de un tema  y se persiste, esta información la necesitamos para la vista del tema.

**Checklist**:
- [ ] Agregue tests (y los corrí localmente)
- [X] Vi que localmente funcionara
- [ ] Probe que en la review app funcionara

