### PR TITLE
Persistir prioridad de un tema

### DIFF
--- a/backend/src/database/migrations/20191204125147-agregar-columna-prioridad-tabla-tema.js
+++ b/backend/src/database/migrations/20191204125147-agregar-columna-prioridad-tabla-tema.js
@@ -1,0 +1,12 @@
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn(
+    'Temas',
+    'prioridad',
+    {
+      type: Sequelize.INTEGER,
+    },
+  ),
+
+  down: (queryInterface, Sequelize) => queryInterface.removeColumn('Temas', 'prioridad'),
+};

--- a/backend/src/database/models/tema.js
+++ b/backend/src/database/models/tema.js
@@ -13,6 +13,7 @@ module.exports = (sequelize, DataTypes) => {
     inicio: DataTypes.DATE,
     fin: DataTypes.DATE,
     cantidadDeMinutosDelTema: DataTypes.INTEGER,
+    prioridad: DataTypes.INTEGER,
   }, {});
   Tema.associate = function (models) {
     Tema.Reunion = Tema.belongsTo(models.Reunion, {as: 'reunion'});

--- a/backend/src/domain/temas/repo.js
+++ b/backend/src/domain/temas/repo.js
@@ -20,7 +20,7 @@ export default class TemasRepo {
   guardarTemas(reunion, temas) {
     return models.Tema.bulkCreate(temas.map((tema) => {
       const temaSanitizado = pick(tema, ['tipo', 'titulo', 'descripcion', 'duracion', 'autor', 'obligatoriedad',
-        'linkDePresentacion', 'propuestas', 'temasParaRepasar', 'cantidadDeMinutosDelTema']);
+        'linkDePresentacion', 'propuestas', 'temasParaRepasar', 'cantidadDeMinutosDelTema','prioridad']);
 
       return { ...temaSanitizado, reunionId: reunion.id };
     }));

--- a/frontend/src/reunion/Reunion.js
+++ b/frontend/src/reunion/Reunion.js
@@ -12,7 +12,7 @@ class Reunion extends React.Component {
     super(props);
     this.state = {
       selectedElement: 'Tema Actual',
-      temas: [{ titulo: 'ALOHA' }, { titulo: 'TEMAZO' }, { titulo: 'MIAMEEE' }],
+      temas: [{ titulo: 'Action items roots anterior' }, { titulo: 'Tema 1' }, { titulo: 'Un tema obligatorio' }],
     };
   }
 

--- a/frontend/src/reunion/Reunion.js
+++ b/frontend/src/reunion/Reunion.js
@@ -4,6 +4,7 @@ import { ReunionContainer } from './Reunion.styled';
 import TemaActual from '../tipos-vista-principal/TemaActual';
 import Presentacion from '../tipos-vista-principal/Presentacion';
 import Analytics from '../tipos-vista-principal/Analytics';
+import Temario from '../temario/Temario';
 
 
 class Reunion extends React.Component {
@@ -11,6 +12,7 @@ class Reunion extends React.Component {
     super(props);
     this.state = {
       selectedElement: 'Tema Actual',
+      temas: [{ titulo: 'ALOHA' }, { titulo: 'TEMAZO' }, { titulo: 'MIAMEEE' }],
     };
   }
 
@@ -28,6 +30,7 @@ class Reunion extends React.Component {
     const VistaSeleccionada = this.obtenerVista();
     return (
       <ReunionContainer>
+        <Temario temas = {this.state.temas}/>
         <VistaSeleccionada/>
         <Sidebar handleSelection={this.handleSelection}
                   selectedElement={this.state.selectedElement}/>

--- a/frontend/src/temario/ListaTemario.js
+++ b/frontend/src/temario/ListaTemario.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  ListaTemasContainer, ListaTemas,
+  ListaTemasContainer, ListaTemas, TituloTema,
 } from './ListaTemario.styled';
 
 
@@ -10,7 +10,9 @@ class ListaTemario extends React.Component {
             <ListaTemasContainer>
                 <ListaTemas>
                     {this.props.temas.map((tema, index) => <li key={`propuesta-${index}`}>
-                        {tema.titulo}
+                        <TituloTema>
+                            {tema.titulo}
+                        </TituloTema>
                     </li>)}
                 </ListaTemas>
             </ListaTemasContainer>

--- a/frontend/src/temario/ListaTemario.js
+++ b/frontend/src/temario/ListaTemario.js
@@ -9,11 +9,9 @@ class ListaTemario extends React.Component {
     return (
             <ListaTemasContainer>
                 <ListaTemas>
-                    {this.props.temas.map((tema, index) => <li key={`propuesta-${index}`}>
-                        <TituloTema>
+                    {this.props.temas.map((tema) => <TituloTema>
                             {tema.titulo}
-                        </TituloTema>
-                    </li>)}
+                        </TituloTema>)}
                 </ListaTemas>
             </ListaTemasContainer>
     );

--- a/frontend/src/temario/ListaTemario.js
+++ b/frontend/src/temario/ListaTemario.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import {
+  ListaTemasContainer, ListaTemas,
+} from './ListaTemario.styled';
+
+
+class ListaTemario extends React.Component {
+  render() {
+    return (
+            <ListaTemasContainer>
+                <ListaTemas>
+                    {this.props.temas.map((tema, index) => <li key={`propuesta-${index}`}>
+                        {tema.titulo}
+                    </li>)}
+                </ListaTemas>
+            </ListaTemasContainer>
+    );
+  }
+}
+
+export default ListaTemario;

--- a/frontend/src/temario/ListaTemario.styled.js
+++ b/frontend/src/temario/ListaTemario.styled.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const ListaTemasContainer = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction:column;
+  align-items:center;
+`;
+
+export const ListaTemas = styled.ul`
+`;

--- a/frontend/src/temario/ListaTemario.styled.js
+++ b/frontend/src/temario/ListaTemario.styled.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { colors, font } from '../styles/theme';
 
 export const ListaTemasContainer = styled.div`
   display: flex;
@@ -8,4 +9,10 @@ export const ListaTemasContainer = styled.div`
 `;
 
 export const ListaTemas = styled.ul`
+`;
+
+export const TituloTema = styled.div`
+  font-family: ${font.p};
+  font-size: 2rem;
+  color: white;
 `;

--- a/frontend/src/temario/ListaTemario.styled.js
+++ b/frontend/src/temario/ListaTemario.styled.js
@@ -9,9 +9,11 @@ export const ListaTemasContainer = styled.div`
 `;
 
 export const ListaTemas = styled.ul`
+  display: flex;
+  flex-direction: column;
 `;
 
-export const TituloTema = styled.div`
+export const TituloTema = styled.li`
   font-family: ${font.p};
   font-size: 2rem;
   color: white;

--- a/frontend/src/temario/Temario.js
+++ b/frontend/src/temario/Temario.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Arrow, TemarioContainer, Temas, Titulo,
 } from './Temario.styled';
+import ListaTemario from './ListaTemario';
 
 class Temario extends React.Component {
   constructor(props) {
@@ -17,6 +18,7 @@ class Temario extends React.Component {
         <Arrow onMouseEnter={() => this.setState({ isActive: true })}> + </Arrow>
         <Temas onMouseLeave={() => this.setState({ isActive: false })}>
           <Titulo> Temario </Titulo>
+          <ListaTemario temas = {this.props.temas}/>
         </Temas>
       </TemarioContainer>
     );

--- a/frontend/src/temario/Temario.styled.js
+++ b/frontend/src/temario/Temario.styled.js
@@ -13,7 +13,7 @@ export const Temas = styled.div`
   min-height: 100vh;
   padding: 1em;
   width: 14.5em;  
-  background: ${colors.secondary};
+  background: ${colors.downy};
 `;
 
 export const Arrow = styled.div`
@@ -26,7 +26,7 @@ export const Arrow = styled.div`
   height: 2em;
   border-bottom-right-radius: 4em;
   border-top-right-radius: 4em;
-  background: ${colors.secondary};
+  background: ${colors.downy};
 `;
 
 export const Titulo = styled.div`

--- a/frontend/src/temario/Temario.styled.js
+++ b/frontend/src/temario/Temario.styled.js
@@ -5,14 +5,14 @@ export const TemarioContainer = styled.div(({ isActive }) => `
   display: flex;
   flex-direction: row-reverse;
   transition: all 0.2s linear;
-  position: relative;
-  left: ${isActive ? '0' : '-14em'};
+  position: fixed;
+  left: ${isActive ? '0' : '-16.5em'};
 `);
 
 export const Temas = styled.div`
   min-height: 100vh;
   padding: 1em;
-  width: 12em;  
+  width: 14.5em;  
   background: ${colors.secondary};
 `;
 


### PR DESCRIPTION
[**Link al Trello**](https://trello.com/c/1jnqbP4Y/24-persistir-el-estado-de-un-tema-5)

**Aceptación**
Persistimos la prioridad de un tema en el backend dado que la necesitamos para poder ordernar los temas por prioridad a la hora de mostrarlos en el front.

**Checklist**:
- [ ] Agregue tests (y los corrí localmente)
- [x] Vi que localmente funcionara
- [ ] Probe que en la review app funcionara

