### PR TITLE
Separar cliente de votacion de "servicio"

### DIFF
--- a/backend/src/domain/temas/sanitizar.js
+++ b/backend/src/domain/temas/sanitizar.js
@@ -1,0 +1,7 @@
+import { pick } from 'lodash';
+
+export default function sanitizar(objeto) {
+  // TODO: Podría ser Object.keys(_models.default.Tema.rawAttributes);?
+  return pick(objeto, ['tipo', 'titulo', 'descripcion', 'duracion', 'autor', 'obligatoriedad',
+    'linkDePresentacion', 'propuestas', 'temasParaRepasar', 'cantidadDeMinutosDelTema']);
+}

--- a/backend/src/domain/temas/sanitizar.js
+++ b/backend/src/domain/temas/sanitizar.js
@@ -1,7 +1,6 @@
 import { pick } from 'lodash';
 
 export default function sanitizar(objeto) {
-  // TODO: Podría ser Object.keys(_models.default.Tema.rawAttributes);?
   return pick(objeto, ['tipo', 'titulo', 'descripcion', 'duracion', 'autor', 'obligatoriedad',
     'linkDePresentacion', 'propuestas', 'temasParaRepasar', 'cantidadDeMinutosDelTema']);
 }

--- a/backend/src/domain/votacionDeRoots/temas-fixture.json
+++ b/backend/src/domain/votacionDeRoots/temas-fixture.json
@@ -15,7 +15,8 @@
         "idDePropuestaOriginal": null,
         "fechaDePropuestaOriginal": null,
         "esRePropuesta": false,
-        "linkDePresentacion": null
+        "linkDePresentacion": null,
+        "cantidadDeMinutosDelTema": 60
     },
     {
         "tipo": "conDescripcion",
@@ -37,7 +38,8 @@
         "idDePropuestaOriginal": null,
         "fechaDePropuestaOriginal": null,
         "esRePropuesta": false,
-        "linkDePresentacion": "https://www.lipsum.com/"
+        "linkDePresentacion": "https://www.lipsum.com/",
+        "cantidadDeMinutosDelTema": 60
     },
     {
         "tipo": "conDescripcion",
@@ -55,7 +57,8 @@
         "idDePropuestaOriginal": null,
         "fechaDePropuestaOriginal": null,
         "esRePropuesta": false,
-        "linkDePresentacion": null
+        "linkDePresentacion": null,
+        "cantidadDeMinutosDelTema": 60
     },
     {
         "tipo": "proponerPinos",
@@ -86,7 +89,8 @@
                     "mail": "ailen.munoz@10pines.com"
                 }
             }
-        ]
+        ],
+        "cantidadDeMinutosDelTema": 60
     },
     {
         "tipo": "repasarActionItems",
@@ -257,6 +261,7 @@
                 "conclusion": null,
                 "fueTratado": false
             }
-        ]
+        ],
+        "cantidadDeMinutosDelTema": 60
     }
 ]

--- a/backend/src/domain/votacionDeRoots/votacionDeRoots.js
+++ b/backend/src/domain/votacionDeRoots/votacionDeRoots.js
@@ -1,20 +1,11 @@
-import fetch from 'node-fetch';
-
-const getTemasRoots = () => {
-  const temasRootsHost = process.env.TEMAS_ROOTS_HOST;
-  const temasRootsApiKey = process.env.TEMAS_ROOTS_API_KEY;
-
-  return fetch(`${temasRootsHost}/api/v2/temas?apiKey=${temasRootsApiKey}`).then(
-    (response) => response.json(),
-  );
-};
-
-const getTemasRootsMock = () => Promise.resolve(require('./temas-fixture.json'));
+import Cliente from './votacionDeRootsCliente';
+import sanitizar from '~/domain/temas/sanitizar';
 
 const VotacionDeRoots = {
-
-  getTemasRoots: process.env.NODE_ENV === 'test' ? getTemasRootsMock : getTemasRoots,
-
+    getTemasRoots: () => {
+        return Cliente.getTemasRoots()
+            .then(temas => temas.map(sanitizar));
+    }
 };
 
 export default VotacionDeRoots;

--- a/backend/src/domain/votacionDeRoots/votacionDeRoots.test.js
+++ b/backend/src/domain/votacionDeRoots/votacionDeRoots.test.js
@@ -1,0 +1,60 @@
+import { getTemasRoots } from './votacionDeRoots';
+import fixture from './temas-fixture.json';
+
+import VotacionCliente from './votacionDeRootsCliente';
+jest.mock('./votacionDeRootsCliente', () => ({
+    getTemasRoots: jest.fn(),
+}));
+
+
+describe('#getTemasRoots', () => {
+    describe('con un cliente mockeado', () => {
+        let respuesta;
+        beforeEach(() => {
+            VotacionCliente.getTemasRoots.mockImplementation(() => Promise.resolve(respuesta));
+        });
+
+        describe('si no hay temas', () => {
+            beforeEach(() => {
+                respuesta = [];
+            });
+
+            it('devuelve una lista vacia', () => {
+                return expect(getTemasRoots()).resolves.toEqual([]);
+            });
+        });
+
+
+        describe('cuando hay un tema bien formado', () => {
+            const unBuenTema = fixture[0];
+            beforeEach(() => {
+                respuesta = [unBuenTema];
+            });
+
+            it('devuelve ese mismo tema', () => {
+                return getTemasRoots().then((temas) => {
+                    const [primerTema, ...resto] = temas;
+
+                    // Nota: Podríamos asertar sobre más valores?
+                    expect(primerTema).toHaveProperty("autor");
+                    expect(resto.length).toEqual(0);
+                });
+            });
+        });
+
+        describe('cuando hay un tema con un atributo de más', () => {
+            const unBuenTema = fixture[0];
+            beforeEach(() => {
+                respuesta = [
+                    { ...unBuenTema, algoDeMas: 300 }
+                ];
+            });
+
+            it('devuelve el tema sanitizado', () => {
+                return expect(getTemasRoots()).resolves.toEqual(
+                    expect.not.objectContaining({ algoDeMas: expect.anything() })
+                );
+            });
+        });
+    });
+});

--- a/backend/src/domain/votacionDeRoots/votacionDeRoots.test.js
+++ b/backend/src/domain/votacionDeRoots/votacionDeRoots.test.js
@@ -36,7 +36,10 @@ describe('#getTemasRoots', () => {
                     const [primerTema, ...resto] = temas;
 
                     // Nota: Podríamos asertar sobre más valores?
-                    expect(primerTema).toHaveProperty("autor");
+                    for (const key of ['tipo', 'titulo', 'descripcion', 'duracion', 'autor', 'obligatoriedad',
+                        'linkDePresentacion', 'cantidadDeMinutosDelTema']) {
+                        expect(primerTema).toHaveProperty(key);
+                    }
                     expect(resto.length).toEqual(0);
                 });
             });

--- a/backend/src/domain/votacionDeRoots/votacionDeRootsCliente.js
+++ b/backend/src/domain/votacionDeRoots/votacionDeRootsCliente.js
@@ -1,0 +1,25 @@
+import fetch from 'node-fetch';
+
+function getTemasRootsDeVerdad() {
+  const temasRootsHost = process.env.TEMAS_ROOTS_HOST;
+  const temasRootsApiKey = process.env.TEMAS_ROOTS_API_KEY;
+
+  return fetch(`${temasRootsHost}/api/v2/temas?apiKey=${temasRootsApiKey}`).then(
+    (response) => response.json(),
+  );
+}
+
+function getTemasRootsMock() {
+  return Promise.resolve(
+      // eslint-disable-next-line import/prefer-default-export
+      require('./temas-fixture.json'),
+  );
+}
+
+const getTemasRoots = process.env.NODE_ENV === 'test' ? getTemasRootsMock : getTemasRootsDeVerdad;
+
+const VotacionCliente = {
+  getTemasRoots
+};
+
+export default VotacionCliente;


### PR DESCRIPTION
1. Separé un servicio de buscar temas de roots (y sanitizarlos) del cliente que hace el request
1. Moví la "santizicación" a un lugar más razonable.
1. Agregué tests con mocks.


**Aceptación**
![image](https://user-images.githubusercontent.com/403456/70148752-853c3b80-1685-11ea-9d15-199bf33350db.png)


**Checklist**:
- [x] Agregue tests (y los corrí localmente)
- [x] Vi que localmente funcionara
- [x] Probe que en la review app funcionara

