### PR TITLE
cambio tipo de dato de columna descripcion de string a text

### DIFF
--- a/backend/src/database/migrations/20191119203213-create-tema.js
+++ b/backend/src/database/migrations/20191119203213-create-tema.js
@@ -14,7 +14,7 @@ module.exports = {
       type: Sequelize.STRING,
     },
     descripcion: {
-      type: Sequelize.STRING,
+      type: Sequelize.TEXT,
     },
     duracion: {
       type: Sequelize.STRING,

--- a/backend/src/database/models/tema.js
+++ b/backend/src/database/models/tema.js
@@ -5,7 +5,7 @@ module.exports = (sequelize, DataTypes) => {
     titulo: DataTypes.STRING,
     descripcion: DataTypes.STRING,
     duracion: DataTypes.STRING,
-    autor: DataTypes.STRING,
+    autor: DataTypes.TEXT,
     obligatoriedad: DataTypes.STRING,
     linkDePresentacion: DataTypes.STRING,
     propuestas: DataTypes.JSON,


### PR DESCRIPTION
[**Link al Trello**](https://trello.com/c/1jnqbP4Y/24-persistir-el-estado-de-un-tema-5)

**Aceptación**
Se cambió el tipo de dato de "String" a "Text" de la columna descripción en la tabla de temas con el objetivo de poder guardar descripciones suficientemente largas (con dato "String" se puede guardar hasta 255 caracteres).

**Checklist**:
- [ ] Agregue tests (y los corrí localmente)
- [x] Vi que localmente funcionara
- [ ] Probe que en la review app funcionara

