### PR TITLE
Corrección de carga cuando la url tiene reunionDeRoots

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -27,7 +27,7 @@ const App = ({ location }) => {
         <Route exact path="/"
                render={() => (reunionDeRoots.abierta ? <Redirect to="/reunionDeRoots"/>
                  : <EmpezarReunion {...reunionDeRoots} location={location}/>)}/>
-        <Route path="/reunionDeRoots"
+        <Route exact path="/reunionDeRoots"
                render={() => (reunionDeRoots.abierta ? <Reunion {...reunionDeRoots} location={location}/> : <Redirect to="/"/>)}/>
       </Switch>
     </>


### PR DESCRIPTION
**Aceptación**

Cuando abrís la app con la url con /reunionDeRoots ahora te lleva a la reunión si está abierta o a la pantalla de inicio si no existe reunión abierta

**Checklist**:
- [ ] Agregue tests (y los corrí localmente)
- [x] Vi que localmente funcionara
- [ ] Probe que en la review app funcionara

