### PR TITLE
Imagenes sidebarizq tamaño adecuado

### DIFF
--- a/frontend/src/components/Button.styled.js
+++ b/frontend/src/components/Button.styled.js
@@ -2,7 +2,13 @@ import styled from 'styled-components';
 import { colors, font } from '../styles/theme';
 
 export const Button = styled.button`
-  font-size: ${font.sizeP};
+  font-family: ${font.p};
+  @media (max-width: 1920px),(max-height: 1080px)  {
+    font-size:  ${font.sizeP};
+  }
+  @media (min-width: 1920px), @media (min-height: 1080px)  {
+    font-size: 1.75em;
+  }
   background: ${(props) => (!props.disabled ? colors.primary : colors.black30)};
   border-radius: 0.2em;
   border: none;

--- a/frontend/src/components/Button.styled.js
+++ b/frontend/src/components/Button.styled.js
@@ -1,12 +1,10 @@
 import styled from 'styled-components';
-import { colors, font } from '../styles/theme';
+import { colors, font, sizeBreakpoint } from '../styles/theme';
 
 export const Button = styled.button`
   font-family: ${font.p};
-  @media (max-width: 1920px),(max-height: 1080px)  {
-    font-size:  ${font.sizeP};
-  }
-  @media (min-width: 1920px), @media (min-height: 1080px)  {
+  font-size:  ${font.sizeP};
+  @media (min-width: ${sizeBreakpoint.bigWidth}), @media (min-height: ${sizeBreakpoint.bigHeight})  {
     font-size: 1.75em;
   }
   background: ${(props) => (!props.disabled ? colors.primary : colors.black30)};

--- a/frontend/src/sidebar-reunion/Sidebar.styled.js
+++ b/frontend/src/sidebar-reunion/Sidebar.styled.js
@@ -35,7 +35,12 @@ export const ElementoContainer = styled.div(({ habilitar }) => `
 
 export const TitulosSidebar = styled.div`
   font-family: ${font.p};
-  font-size: ${font.sizeP};
+  @media (max-width: 1920px),(max-height: 1080px)  {
+    font-size:  ${font.sizeP};
+  }
+  @media (min-width: 1920px), @media (min-height: 1080px)  {
+    font-size: 1.75rem;
+  }
   text-align: center;
   padding-bottom: 7%;
 `;

--- a/frontend/src/sidebar-reunion/Sidebar.styled.js
+++ b/frontend/src/sidebar-reunion/Sidebar.styled.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { colors, font } from '../styles/theme';
+import { colors, font, sizeBreakpoint } from '../styles/theme';
 
 export const SidebarContainer = styled.div`
   display: flex;
@@ -35,10 +35,8 @@ export const ElementoContainer = styled.div(({ habilitar }) => `
 
 export const TitulosSidebar = styled.div`
   font-family: ${font.p};
-  @media (max-width: 1920px),(max-height: 1080px)  {
-    font-size:  ${font.sizeP};
-  }
-  @media (min-width: 1920px), @media (min-height: 1080px)  {
+  font-size:  ${font.sizeP};
+  @media (min-width: ${sizeBreakpoint.bigWidth}), @media (min-height: ${sizeBreakpoint.bigHeight})  {
     font-size: 1.75rem;
   }
   text-align: center;

--- a/frontend/src/styles/theme.js
+++ b/frontend/src/styles/theme.js
@@ -33,3 +33,8 @@ export const variables = {
 export const translucid = {
   green: 'rgba(104, 201, 178, 0.7)',
 };
+
+export const sizeBreakpoint = {
+  bigWidth: '1920px',
+  bigHeight: '1080px',
+};

--- a/frontend/src/temario/InfoItemContainer.styled.js
+++ b/frontend/src/temario/InfoItemContainer.styled.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { colors, font } from '../styles/theme';
+import { colors, font, sizeBreakpoint } from '../styles/theme';
 
 export const InfoItemContainer = styled.div`
   display:flex;
@@ -13,11 +13,9 @@ export const InfoImageContainer = styled.div`
   justify-content: center;
   border-radius: 50%;
   border: 0.25rem solid ${colors.viridian};
-  @media (max-width: 1920px),(max-height: 1080px)  {
-    height: 9rem;
-    width: 9rem;
-  }
-  @media (min-width: 1920px), @media (min-height: 1080px)  {
+  height: 9rem;
+  width: 9rem;
+  @media (min-width: ${sizeBreakpoint.bigWidth}), @media (min-height: ${sizeBreakpoint.bigHeight}) {
     height: 15rem;
     width: 15rem;
   }
@@ -35,10 +33,8 @@ export const InfoImage = styled.img`
 
 
 export const Texto = styled.p`
-@media (max-width: 1920px),(max-height: 1080px)  {
-  font-size: 1rem;
-}
-@media (min-width: 1920px), @media (min-height: 1080px)  {
+font-size: 1rem;
+@media (min-width: ${sizeBreakpoint.bigWidth}), @media (min-height: ${sizeBreakpoint.bigHeight})  {
   font-size: 2rem;
 }
 font-family: ${font.p};

--- a/frontend/src/temario/InfoItemContainer.styled.js
+++ b/frontend/src/temario/InfoItemContainer.styled.js
@@ -13,8 +13,14 @@ export const InfoImageContainer = styled.div`
   justify-content: center;
   border-radius: 50%;
   border: 0.25rem solid ${colors.viridian};
-  height: 8rem;
-  width: 8rem;
+  @media (max-width: 1920px),(max-height: 1080px)  {
+    height: 9rem;
+    width: 9rem;
+  }
+  @media (min-width: 1920px), @media (min-height: 1080px)  {
+    height: 15rem;
+    width: 15rem;
+  }
   overflow: hidden;
   background: ${colors.white};
   padding: 1.25rem;
@@ -29,8 +35,12 @@ export const InfoImage = styled.img`
 
 
 export const Texto = styled.p`
-
-font-size: 1rem ;
+@media (max-width: 1920px),(max-height: 1080px)  {
+  font-size: 1rem;
+}
+@media (min-width: 1920px), @media (min-height: 1080px)  {
+  font-size: 2rem;
+}
 font-family: ${font.p};
 color:white;
 margin-top: 1em;

--- a/frontend/src/temario/TemaItem.styled.js
+++ b/frontend/src/temario/TemaItem.styled.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { colors, font } from '../styles/theme';
+import { colors, font, sizeBreakpoint } from '../styles/theme';
 
 export const TemaItemContainer = styled.li`
   display: flex;
@@ -10,10 +10,8 @@ export const TemaItemContainer = styled.li`
 
 export const TituloTema = styled.div`
   font-family: ${font.p};
-  @media (max-width: 1920px),(max-height: 1080px)  {
-    font-size:  ${font.sizeP};
-  }
-  @media (min-width: 1920px), @media (min-height: 1080px)  {
+  font-size:  ${font.sizeP};
+  @media (min-width: ${sizeBreakpoint.bigWidth}), @media (min-height: ${sizeBreakpoint.bigHeight})  {
     font-size: 2rem;
   }
   letter-spacing: 1px;

--- a/frontend/src/temario/TemaItem.styled.js
+++ b/frontend/src/temario/TemaItem.styled.js
@@ -10,7 +10,12 @@ export const TemaItemContainer = styled.li`
 
 export const TituloTema = styled.div`
   font-family: ${font.p};
-  font-size:  ${font.sizeP};
+  @media (max-width: 1920px),(max-height: 1080px)  {
+    font-size:  ${font.sizeP};
+  }
+  @media (min-width: 1920px), @media (min-height: 1080px)  {
+    font-size: 2rem;
+  }
   letter-spacing: 1px;
   color: ${colors.viridian};
   max-width: calc(100% - 2.5rem)

--- a/frontend/src/temario/Temario.styled.js
+++ b/frontend/src/temario/Temario.styled.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { colors, font } from '../styles/theme';
+import { colors, font, sizeBreakpoint } from '../styles/theme';
 
 export const TemarioContainer = styled.div(({ isActive }) => `
   display: flex;
@@ -37,10 +37,8 @@ export const Arrow = styled.img`
 
 export const LeyendaEmpresa = styled.div`
   font-family: ${font.p};
-  @media (max-width: 1920px),(max-height: 1080px)  {
-    font-size:  ${font.sizeH1};
-  }
-  @media (min-width: 1920px), @media (min-height: 1080px)  {
+  font-size:  ${font.sizeH1};
+  @media (min-width: ${sizeBreakpoint.bigWidth}), @media (min-height: ${sizeBreakpoint.bigHeight})  {
     font-size: 4rem;
   }
   letter-spacing: -3px;
@@ -49,10 +47,8 @@ export const LeyendaEmpresa = styled.div`
 
 export const ExtensionLeyendaEmpresa = styled.div`
   font-family: ${font.p};
-  @media (max-width: 1920px),(max-height: 1080px)  {
-    font-size:  ${font.sizeP};
-  }
-  @media (min-width: 1920px), @media (min-height: 1080px)  {
+  font-size:  ${font.sizeP};
+  @media (min-width: ${sizeBreakpoint.bigWidth}), @media (min-height: ${sizeBreakpoint.bigHeight})  {
     font-size: 1.75rem;
   }
   color: white;
@@ -61,10 +57,8 @@ export const ExtensionLeyendaEmpresa = styled.div`
 
 export const Titulo = styled.div`
   font-family: ${font.h1};
-  @media (max-width: 1920px),(max-height: 1080px)  {
-    font-size:  ${font.sizeH2};
-  }
-  @media (min-width: 1920px), @media (min-height: 1080px)  {
+  font-size:  ${font.sizeH2};
+  @media (min-width: ${sizeBreakpoint.bigWidth}), @media (min-height: ${sizeBreakpoint.bigHeight}) {
     font-size: 3rem;
   }
   letter-spacing: 1px;

--- a/frontend/src/temario/Temario.styled.js
+++ b/frontend/src/temario/Temario.styled.js
@@ -37,21 +37,36 @@ export const Arrow = styled.img`
 
 export const LeyendaEmpresa = styled.div`
   font-family: ${font.p};
-  font-size:  ${font.sizeH1};
+  @media (max-width: 1920px),(max-height: 1080px)  {
+    font-size:  ${font.sizeH1};
+  }
+  @media (min-width: 1920px), @media (min-height: 1080px)  {
+    font-size: 4rem;
+  }
   letter-spacing: -3px;
   color: white;
 `;
 
 export const ExtensionLeyendaEmpresa = styled.div`
   font-family: ${font.p};
-  font-size: 1rem;
+  @media (max-width: 1920px),(max-height: 1080px)  {
+    font-size:  ${font.sizeP};
+  }
+  @media (min-width: 1920px), @media (min-height: 1080px)  {
+    font-size: 1.75rem;
+  }
   color: white;
   margin-bottom: 2em;
 `;
 
 export const Titulo = styled.div`
   font-family: ${font.h1};
-  font-size:  ${font.sizeH2};
+  @media (max-width: 1920px),(max-height: 1080px)  {
+    font-size:  ${font.sizeH2};
+  }
+  @media (min-width: 1920px), @media (min-height: 1080px)  {
+    font-size: 3rem;
+  }
   letter-spacing: 1px;
   color: white;
 `;

--- a/frontend/src/temario/descripcion-tipo-tema/DescripcionTema.styled.js
+++ b/frontend/src/temario/descripcion-tipo-tema/DescripcionTema.styled.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { font } from '../../styles/theme';
+import { font, sizeBreakpoint } from '../../styles/theme';
 
 
 export const DescripcionTemaContainer = styled.div`
@@ -17,10 +17,8 @@ export const Titulo = styled.h1`
 
 export const Descripcion = styled.p`
   font-family: ${font.p};
-  @media (max-width: 1920px),(max-height: 1080px)  {
-    font-size:  ${font.sizeP};
-  }
-  @media (min-width: 1920px), @media (min-height: 1080px)  {
+  font-size:  ${font.sizeP};
+  @media (min-width: ${sizeBreakpoint.bigWidth}), @media (min-height: ${sizeBreakpoint.bigHeight})  {
     font-size: 2rem;
   }
   white-space: pre-line;

--- a/frontend/src/temario/descripcion-tipo-tema/DescripcionTema.styled.js
+++ b/frontend/src/temario/descripcion-tipo-tema/DescripcionTema.styled.js
@@ -16,11 +16,16 @@ export const Titulo = styled.h1`
 `;
 
 export const Descripcion = styled.p`
+  font-family: ${font.p};
+  @media (max-width: 1920px),(max-height: 1080px)  {
+    font-size:  ${font.sizeP};
+  }
+  @media (min-width: 1920px), @media (min-height: 1080px)  {
+    font-size: 2rem;
+  }
   white-space: pre-line;
   text-align: justify;
   margin: 0 3em;
-  font-size: ${font.sizeP} ;
-  font-family: ${font.p};
 `;
 
 export const ListaPinosPropuestos = styled.ul`


### PR DESCRIPTION
[**Link al Trello**](https://trello.com/c/qnH6MbrO/43-arreglar-detalles-de-visualizaci%C3%B3n-de-im%C3%A1genes-con-la-informaci%C3%B3n-del-tema)

**Aceptación**

Se agrandaron imágenes del sidebar izquierdo y los font-size de todos los textos para que se visualicen bien en una resolución de 1920x1080 (se usan media queries con tal fin)
![Captura de pantalla de 2019-12-10 12-37-26](https://user-images.githubusercontent.com/22490655/70544529-faf34c00-1b4a-11ea-871e-11e690d03674.png)

![Captura de pantalla de 2019-12-10 12-46-18](https://user-images.githubusercontent.com/22490655/70544588-18c0b100-1b4b-11ea-9641-3b7a9073be5d.png)



**Checklist**:
- [ ] Agregue tests (y los corrí localmente)
- [ ] Vi que localmente funcionara
- [ ] Probe que en la review app funcionara

