### PR TITLE
Bug fix de cuando el countdown se quedaba sin tiempo

### DIFF
--- a/frontend/src/reunion/Countdown.js
+++ b/frontend/src/reunion/Countdown.js
@@ -50,7 +50,7 @@ export default class Countdown extends React.Component {
 
     return (
             <CountdownContainer>
-                { this.state.segundos === 0
+                { this.state.segundos <= 0
                   ? 'Tiempo Acabado'
                   : <span>{minutos}:{segundos < 10 ? `0${segundos}` : segundos}</span>
                 }


### PR DESCRIPTION
Cuando el countdown se quedaba sin tiempo y la página era recargada se mostraba el tiempo de manera incorrecta.

**Checklist**:
- [ ] Agregue tests (y los corrí localmente)
- [x] Vi que localmente funcionara
- [ ] Probe que en la review app funcionara

