### PR TITLE
Usar sha512 en lugar de sha1 en package-lock.json

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8381,7 +8381,7 @@
     "history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha1-MzcaZeOoOyZ0NOKz87G0xYqtTPM=",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "loose-envify": "^1.2.0",
@@ -15149,7 +15149,7 @@
     "resolve-pathname": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha1-mdAiJNPPJjaJvsuzk7xWAxMCXc0="
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -17132,7 +17132,7 @@
     "value-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha1-Hgt5THNMXAyt4XnEN9NW2TGjTWw="
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",


### PR DESCRIPTION
## Problema
La versión de node/npm que usamos utiliza sha512, pero por alguna razón el `package-lock.json` que tenemos en el repo usa sha1.

## Solución
Actualizar el archivo `package-lock.json` para que coincida con el resultado generado luego de hacer `npm install` con la versión correcta de npm.