### PR TITLE
Arreglo de visualización de cards en la pantalla de debate

### DIFF
--- a/frontend/src/cola-de-participantes/ParticipantsCard.styled.js
+++ b/frontend/src/cola-de-participantes/ParticipantsCard.styled.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 export const CardContainer = styled.div(({isTalking}) => `
   display: flex;
+  flex-shrink: 0;
   flex-direction: column;
   align-items: center;
   background: linear-gradient(145deg, #c7c7c7, #ececec);

--- a/frontend/src/cola-de-participantes/ParticipantsQueue.js
+++ b/frontend/src/cola-de-participantes/ParticipantsQueue.js
@@ -3,8 +3,7 @@ import {
   QueueContainer,
   QueuedCardsLeftContainerStyle,
   QueuedCardsRightContainerStyle,
-  QueuedLeftCardsStyle,
-  QueuedRightCardsStyle,
+  CenterCard,
 } from './ParticipantsQueue.styled';
 import ParticipantsCard from './ParticipantsCard';
 
@@ -18,7 +17,6 @@ const ParticipantsQueue = ({ participants = [], isTalking }) => {
 
   return (
     <QueueContainer>
-      <QueuedLeftCardsStyle>
         <QueuedCardsLeftContainerStyle>
           { getQueuedParticipants()
             .map((participant, index) => <ParticipantsCard
@@ -26,15 +24,14 @@ const ParticipantsQueue = ({ participants = [], isTalking }) => {
               key={index}/>)
           }
         </QueuedCardsLeftContainerStyle>
-      </QueuedLeftCardsStyle>
-      {getTalkingParticipant() && <ParticipantsCard participant={getTalkingParticipant()} isParticipantTalking/>}
-      <QueuedRightCardsStyle>
+        <CenterCard>
+          {getTalkingParticipant() && <ParticipantsCard participant={getTalkingParticipant()} isParticipantTalking/>}
+        </CenterCard>
         <QueuedCardsRightContainerStyle>
           { getParticipantsThatAlreadyTalked().map((participant, index) => <ParticipantsCard
 
             participant={participant} key={index}/>)}
         </QueuedCardsRightContainerStyle>
-      </QueuedRightCardsStyle>
     </QueueContainer>
   );
 };

--- a/frontend/src/cola-de-participantes/ParticipantsQueue.styled.js
+++ b/frontend/src/cola-de-participantes/ParticipantsQueue.styled.js
@@ -1,32 +1,34 @@
 import styled from 'styled-components';
 
 export const QueueContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
+  display: grid;
+  grid-template-areas: "a b c";
+  grid-template-columns: 35vw auto 35vw;
+  height: 50%;
+  gap: 1rem;
+  align-items:center;
+  justify-content:center;
 `;
 
-export const QueuedLeftCardsStyle = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 40rem;
-  align-items: center;
-`;
-
-export const QueuedRightCardsStyle = styled(QueuedLeftCardsStyle)`
-  opacity: 0.5;
-`;
 
 export const QueuedCardsLeftContainerStyle = styled.div`
+  grid-area: a;
+  justify-self: end;
+
   display: flex;
-  width: 100%;
+  flex-direction: row-reverse;
 `;
 
 export const QueuedCardsRightContainerStyle = styled.div`
-  display: grid;
-  grid-gap: 1rem;
-  grid-auto-flow: column;
-  align-items: center;
-  width: 100%;
+  grid-area: c;
+  justify-self: start;
+
+  display: flex;
+  flex-direction: row-reverse;
+  opacity: 0.5;
 `;
+
+export const CenterCard = styled.div`
+  grid-area: b;
+`;
+

--- a/frontend/src/cola-de-participantes/ParticipantsQueue.styled.js
+++ b/frontend/src/cola-de-participantes/ParticipantsQueue.styled.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const QueueContainer = styled.div`
   display: grid;
-  grid-template-areas: "a b c";
+  grid-template-areas: "left center right";
   grid-template-columns: 35vw auto 35vw;
   height: 50%;
   gap: 1rem;
@@ -12,15 +12,14 @@ export const QueueContainer = styled.div`
 
 
 export const QueuedCardsLeftContainerStyle = styled.div`
-  grid-area: a;
-  justify-self: end;
+  grid-area: left;
 
   display: flex;
   flex-direction: row-reverse;
 `;
 
 export const QueuedCardsRightContainerStyle = styled.div`
-  grid-area: c;
+  grid-area: right;
   justify-self: start;
 
   display: flex;
@@ -29,6 +28,6 @@ export const QueuedCardsRightContainerStyle = styled.div`
 `;
 
 export const CenterCard = styled.div`
-  grid-area: b;
+  grid-area: center;
 `;
 

--- a/frontend/src/debate-handler/Debate.styled.js
+++ b/frontend/src/debate-handler/Debate.styled.js
@@ -17,12 +17,3 @@ export const GraphsContainer = styled.div`
     align-items: center;
     justify-content: space-between;
 `;
-
-export const ParticipantsContainer = styled.div`  
-    display: flex;
-    flex-direction: column;
-    background-color: white;
-    height: 50%
-    align-items: center;
-    justify-content: center;
-`;

--- a/frontend/src/tipos-vista-principal/Debate.js
+++ b/frontend/src/tipos-vista-principal/Debate.js
@@ -25,9 +25,7 @@ const Debate = ({tema}) => {
         <ChartLine data={debateData.dataLine} inicioTema={tema.inicio}/>
         <ChartBar data={debateData.dataBar}/>
       </GraphsContainer>
-      <ParticipantsContainer>
         <ParticipantsQueue participants={debateData.participants} isTalking={isTalking}/>
-      </ParticipantsContainer>
     </SubDebateContainer>
   );
 };


### PR DESCRIPTION
https://trello.com/c/1J2D1L42/81-bug-fila-de-personas-que-ya-hablaron-muestra-al-ultimo-que-hablo-primero-y-la-fila-de-la-izquierda-se-achica-si-aparecen-m%C3%A1s

**Aceptación**
![Screenshot from 2020-04-07 21-26-22](https://user-images.githubusercontent.com/11772500/78731593-88d31e00-7916-11ea-9f0b-c1517e20c2b3.png)

**Checklist**:
- [ ] Agregue tests (y los corrí localmente)
- [ ] Vi que localmente funcionara
- [ ] Probe que en la review app funcionara

