### PR TITLE
Fix actualizar componentes sin refrescar la pagina

### DIFF
--- a/backend/src/domain/eventos/controller.js
+++ b/backend/src/domain/eventos/controller.js
@@ -1,7 +1,7 @@
 import AsyncLock from 'async-lock';
 import context from '~/context';
 
-const Controller = () => {
+const Controller = (wss) => {
   const lock = new AsyncLock();
 
   return ({

--- a/backend/src/domain/eventos/router.js
+++ b/backend/src/domain/eventos/router.js
@@ -2,9 +2,9 @@ import { Router } from 'express';
 import asyncMiddleware from '~/utils/asyncMiddleware';
 import Controller from './controller';
 
-export default () => {
+export default (wss) => {
   const router = Router({ promise: true });
-  const controller = Controller();
+  const controller = Controller(wss);
 
   router.post('/', asyncMiddleware(controller.publicar));
   return router;

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -9,7 +9,7 @@ import logger from '~/logger';
 import eventosRouter from './domain/eventos/router';
 import webSocketRouter from '~/webSocket';
 
-export default () => {
+export default (wss) => {
   const router = Router({ promise: true });
 
   router.use('/auth', loginRouter);
@@ -30,7 +30,7 @@ export default () => {
 
   router.use('/', reunionRouter);
 
-  router.use('/eventos', eventosRouter());
+  router.use('/eventos', eventosRouter(wss));
   router.use('/temas', temasRouter);
   router.use('/perfil', perfilRouter);
   router.ws('/ws', webSocketRouter());

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2,7 +2,6 @@ import express, { json, urlencoded } from 'express';
 import morgan from 'morgan';
 import * as path from 'path';
 import cookieSession from 'cookie-session';
-import webSocketRouter from './webSocket';
 
 import apiRouter from './routes';
 import logger from '~/logger';
@@ -36,7 +35,6 @@ app.use(json());
 app.use(urlencoded({ extended: false }));
 
 app.use(cookieSession(cookieOptions));
-app.ws('/ws', webSocketRouter(expressWs.getWss()));
 
 app.use('/api', apiRouter(expressWs.getWss()));
 if (process.env.NODE_ENV === 'production') {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2,12 +2,13 @@ import express, { json, urlencoded } from 'express';
 import morgan from 'morgan';
 import * as path from 'path';
 import cookieSession from 'cookie-session';
+import webSocketRouter from './webSocket';
 
 import apiRouter from './routes';
 import logger from '~/logger';
 
 const app = express();
-require('express-ws')(app);
+const expressWs = require('express-ws')(app);
 
 const cookieOptions = {
   name: 'ruth_session',
@@ -35,8 +36,9 @@ app.use(json());
 app.use(urlencoded({ extended: false }));
 
 app.use(cookieSession(cookieOptions));
+app.ws('/ws', webSocketRouter(expressWs.getWss()));
 
-app.use('/api', apiRouter());
+app.use('/api', apiRouter(expressWs.getWss()));
 if (process.env.NODE_ENV === 'production') {
   app.use(express.static(path.join(__dirname, './frontend')));
   app.use('*', (req, res) => {


### PR DESCRIPTION
Solucionado bug que hacia que no se actualicen timer/reacciones sin refrescar la pagina, revirtiendo cambios introducidos en #144 que provocaban que el controller de evento no reciba los websockets.

[**Link al Trello**](https://trello.com/c/DEE2sMO2)

**Aceptación**
Ya no hace falta recargar cuando:
* Alguien se encola para hablar (se ve reflejado en la pantalla de debate, y en la pantalla mobile)
* Alguien reacciona (tambien se ve en la pantalla debate)
* Se arranca o frena un tema (el timer responde acorde)

**Checklist**:
- [x] Corri los tests localmente
- [x] Vi que localmente funcionara
- [x] Probe que en la review app funcionara

