### PR TITLE
Refactor reaction buttons to match reaction colors

### DIFF
--- a/frontend/src/cola-de-participantes/TalkingReactions.js
+++ b/frontend/src/cola-de-participantes/TalkingReactions.js
@@ -16,16 +16,12 @@ class TalkingReactionButton extends React.Component {
         paddingLeft: 0,
         paddingRight: 0,
         maxWidth: "none"
-    }
-    backgroundActivo = 'linear-gradient(90deg, rgba(220,223,3,1) 0%, rgba(255,252,184,1) 100%)'
-
-    backgroundInactivo = 'linear-gradient(90deg, rgba(255,255,255,1) 30%, rgba(187,187,186,1) 97%)'
+    };
 
     render() {
         return <Grid item xs={4} justify="center" alignItems="center" style={this.estiloGrilla}>
             <ReactionButton
-                inactiveBackground={this.backgroundInactivo}
-                activeBackground={this.backgroundActivo}
+                activeBackground={'#FFD152'}
                 isBig
                 isActive={this.props.active} icon={this.props.icon}
                 onClick={this.handleReaction}/>

--- a/frontend/src/mobile/ReactionButton.js
+++ b/frontend/src/mobile/ReactionButton.js
@@ -1,13 +1,10 @@
 import React from 'react';
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { darken, lighten } from '@material-ui/core/styles';
+import { colors } from '../styles/theme';
 
 export class ReactionButton extends React.Component {
   getReactionButtonStyle = () => {
-
-  // no me pareció mal dejarle estilos default, por si se quiere usar el boton con la misma gama de colores original
-  let defaultColorOrPassedColor = this.props.inactiveBackground ? this.props.inactiveBackground : 'linear-gradient(145deg, rgb(230, 230, 230), rgb(200, 200, 200)';
-
-  let defaultOrPassedActiveColor = this.props.activeBackground ? this.props.activeBackground : 'linear-gradient(145deg, rgb(114, 181, 114), rgb(205, 255, 205))';
 
   return ({
     height: this.props.isBig ? '3.5em' : '2.5em',
@@ -20,12 +17,22 @@ export class ReactionButton extends React.Component {
     alignItems: 'center',
     justifyContent: 'center',
     opacity: this.props.isDisabled ? '0.5' : (this.props.isActive? '1' : '0.7'),
-    background: this.props.isActive ? defaultOrPassedActiveColor
-      : defaultColorOrPassedColor,
+    background: this.getBackgroundColor(),
     boxShadow: '4px 4px 10px #828282, -4px -4px 10px #ffffff',
     transition: 'opacity 0.1s ease-in',
   });
 };
+
+  getBackgroundColor() {
+    let backgroundColor;
+    if(this.props.isActive){
+      backgroundColor = this.props.activeBackground ? this.props.activeBackground : colors.defaultActiveBackground;
+      return `linear-gradient(145deg, ${darken(backgroundColor, 0.25)}, ${lighten(backgroundColor, 0.5)})`;
+    } else {
+      backgroundColor = colors.defaultInactiveBackground;
+      return `linear-gradient(145deg, ${lighten(backgroundColor, 0.75)}, ${darken(backgroundColor, 0.25)})`;
+    }
+  }
 
   getStatusColor = () => {
     if (this.props.isActive) {

--- a/frontend/src/mobile/vista.js
+++ b/frontend/src/mobile/vista.js
@@ -32,6 +32,7 @@ import { reactionTypes } from '../store/reacciones';
 import { SkeletonCircle, SkeletonLine, ReactionSkeletonContainer } from '../skeleton/Skeleton.styled';
 import { reacciones } from './actions';
 import { faSlack } from '@fortawesome/free-brands-svg-icons';
+import { colors } from '../../src/styles/theme.js'
 
 const logoImage = 'https://res-4.cloudinary.com/crunchbase-production/image/upload/c_lpad,h_256,w_'
   + '256,f_auto,q_auto:eco/wuhk5weer0fkhmh2oyhv';
@@ -101,16 +102,20 @@ const Vista = ({
         <ReactionButton
           isBig isActive={thumbsUp}
           isDisabled={thumbsDown} icon={faThumbsUp}
+          activeBackground={colors.thumbsUp}
           onClick={() => handleReaction(reacciones.THUMBS_UP, thumbsUp)}/>
         <ReactionButton
           isBig isActive={thumbsDown}
           isDisabled={thumbsUp} icon={faThumbsDown}
+          activeBackground={colors.thumbsDown}
           onClick={() => handleReaction(reacciones.THUMBS_DOWN, thumbsDown)}/>
         <ReactionButton
+          activeBackground={colors.slack}
           isBig isActive={slack} icon={faSlack}
           onClick={() => handleReaction(reacciones.SLACK, slack)}/>
         <ReactionButton
           isBig isActive={redondear} icon={faSync}
+          activeBackground={colors.roundUp}
           onClick={() => handleReaction(reacciones.REDONDEAR, redondear)}/>
       </ReactionsContainer>
     );

--- a/frontend/src/styles/theme.js
+++ b/frontend/src/styles/theme.js
@@ -25,6 +25,12 @@ export const colors = {
   viridian: '#448475',
   downy: '#68c9b2',
   white: '#FFFFFF',
+  thumbsUp: '#68A1EA',
+  thumbsDown: '#FFB3BA',
+  slack: '#FFDFBA',
+  roundUp: '#68C9B2',
+  defaultInactiveBackground: '#E6E6E6',
+  defaultActiveBackground: '#72B572',
 };
 
 export const variables = {


### PR DESCRIPTION
https://trello.com/c/6k9N6ofq/129-app-mobile-color-de-los-botones-presionados-respete-el-color-de-las-reacciones-en-la-app-de-presentaci%C3%B3n

![Peek 2020-06-17 18-57](https://user-images.githubusercontent.com/11772500/84954841-8a665280-b0cc-11ea-926b-560f82ca64bb.gif)

Hice un refactor a la parte de los colores de las reacciones para que esté más ordenado y sea más simple setearle nuevos colores a los botones!

Pude haber cambiado el color a las reacciones de las personas en el proceso! :eyes: 

**Checklist**:
- [ ] Agregue tests (y los corrí localmente)
- [x] Vi que localmente funcionara
- [ ] Probe que en la review app funcionara

