### PR TITLE
Envio de estado de los temas de la reunion al backend

### DIFF
--- a/frontend/src/api/backend.js
+++ b/frontend/src/api/backend.js
@@ -15,8 +15,8 @@ const Backend = {
     return requester.post('/reunionDeRoots', { abierta: true });
   },
 
-  cerrarReunion() {
-    return requester.put('/reunionActual', { abierta: false });
+  cerrarReunion(temas) {
+    return requester.put('/reunionActual', { abierta: false, temas });
   },
 
   getPerfil() {

--- a/frontend/src/reunion/TemasHandler.js
+++ b/frontend/src/reunion/TemasHandler.js
@@ -28,8 +28,8 @@ class TemasHandler extends React.Component {
     this.dispatchTema({ tipo: datosTema.fin ? 'Terminar Tema' : 'Empezar Tema', idTema: datosTema.id });
   };
 
-  cerrarReunion = () => {
-    backend.cerrarReunion()
+  cerrarReunion = (temas) => {
+    backend.cerrarReunion(temas)
       .then(() => toast.success('Reunión finalizada'))
       .then(() => {
         this.setState({ redirect: true });

--- a/frontend/src/reunion/VistaTemas.js
+++ b/frontend/src/reunion/VistaTemas.js
@@ -54,7 +54,7 @@ const VistaTemas = ({actualizarTema, cerrarReunion, temas, usuario}) => {
     if (temaActivo()) {
       terminarTema();
     }
-    cerrarReunion();
+    cerrarReunion(temas);
   };
 
   const seleccionarTema = (nuevoTemaSeleccionado) => {


### PR DESCRIPTION
**Aceptación**
Este PR modifica el endpoint de actualizar una reunion, para que se envien todos los temas de la reunion cuando esta se cierra. Esto permite poder trabajar desde el backend con todo lo disponible en el frontend, action items, oradores, reacciones, etc.

**Checklist**:
- [x] Vi que localmente funcionara
- [x] Probe que en la review app funcionara

