### PR TITLE
Cambia el wording cuando se edita el texto de un resumen de orador!

### DIFF
--- a/frontend/src/minuta/ResumenOrador.js
+++ b/frontend/src/minuta/ResumenOrador.js
@@ -8,7 +8,8 @@ import {ResumenInput,
 
 export const ResumenOrador = ({exposicion, onDiscard, onSave})=>{
 
-    let [resumen, setResumen] = useState('')
+    const [resumen, setResumen] = useState('')
+    const [fueEditado, setFueEditado] = useState(false)
 
     useEffect(()=>{
         if(exposicion) setResumen(exposicion.resumen || "")
@@ -28,19 +29,25 @@ export const ResumenOrador = ({exposicion, onDiscard, onSave})=>{
     const onDiscardSummary = ()=>{
         onDiscard()
         setResumen('')
+        setFueEditado(false)
     }
 
     const onGuardarResumen = ()=>{
         onSave(resumen)
         setResumen('')
+        setFueEditado(false)
     }
 
+    const onValueChange = (e)=> {
+        setResumen(e.target.value)
+        setFueEditado(true)
+    };
     return(
         <ContenedorResumen key="container">
             <TituloDeResumen  disabled={isButtonDisabled()}>{TitleText()}</TituloDeResumen>
-            <ResumenInput value={resumen} onChange={(e)=>setResumen(e.target.value)} disabled={isButtonDisabled()} rows={10}/>
+            <ResumenInput value={resumen} onChange={onValueChange} disabled={isButtonDisabled()} rows={10}/>
             <BotonesDeResumen>
-            <TextButton onClick={onDiscardSummary} disabled={isButtonDisabled()}>Descartar cambios</TextButton>
+            <TextButton onClick={onDiscardSummary} disabled={isButtonDisabled()}>{fueEditado? "Descartar cambios" : "Cancelar"}</TextButton>
             <ThemedButton onClick={onGuardarResumen} disabled={isButtonDisabled()}>Guardar</ThemedButton>
             </BotonesDeResumen>
         </ContenedorResumen>


### PR DESCRIPTION
[**Link al Trello**](https://trello.com/c/ID_DE_LA_CARD)

**Aceptación**
Cuando se selecciona un resumen de orador, el boton para arrepentirse se llama Cancelar y ni bien comienza a escribir este botón se convierte en "Descartar cambios"

**Checklist**:
- [x] Vi que localmente funcionara
- [ ] Probe que en la review app funcionara

