### PR TITLE
Opcion de borrar y refactor de estilos del editor de action items

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,16 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import { Slide, toast } from 'react-toastify';
-import { Route, Switch } from 'react-router-dom';
+import React, {useEffect, useState} from 'react';
+import {Slide, toast} from 'react-toastify';
+import {Route, Switch} from 'react-router-dom';
 import GlobalStyle from './GlobalStyle.styled';
 import EmpezarReunion from './empezar-reunion/EmpezarReunion';
 import backend from './api/backend';
 import './toast.css';
-import { useRuthConnectedStore } from './ReduxWebSocketWrapper';
+import {useRuthConnectedStore} from './ReduxWebSocketWrapper';
 import Mobile from './mobile';
 import TemasHandler from './reunion/TemasHandler';
 import NotFound from './common-pages/NotFound';
 import Loading from './common-pages/Loading';
-import { Provider } from 'react-redux';
+import {Provider} from 'react-redux';
 
 const App = ({ usuario }) => {
   const [reunion, setReunion] = useState();

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,16 +1,16 @@
-import React, {useEffect, useState} from 'react';
-import {Slide, toast} from 'react-toastify';
-import {Route, Switch} from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { Slide, toast } from 'react-toastify';
+import { Route, Switch } from 'react-router-dom';
 import GlobalStyle from './GlobalStyle.styled';
 import EmpezarReunion from './empezar-reunion/EmpezarReunion';
 import backend from './api/backend';
 import './toast.css';
-import {useRuthConnectedStore} from './ReduxWebSocketWrapper';
+import { useRuthConnectedStore } from './ReduxWebSocketWrapper';
 import Mobile from './mobile';
 import TemasHandler from './reunion/TemasHandler';
 import NotFound from './common-pages/NotFound';
 import Loading from './common-pages/Loading';
-import {Provider} from 'react-redux';
+import { Provider } from 'react-redux';
 
 const App = ({ usuario }) => {
   const [reunion, setReunion] = useState();

--- a/frontend/src/minuta/ActionItemEditor.js
+++ b/frontend/src/minuta/ActionItemEditor.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {
   BotonBorrar,
   BotonCancelar,

--- a/frontend/src/minuta/ActionItemEditor.js
+++ b/frontend/src/minuta/ActionItemEditor.js
@@ -1,8 +1,10 @@
-import React, {useState, useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import {
+  BotonBorrar,
   BotonCancelar,
   BotonEnviar,
-  ContenedorBotonesActionItem, ContenedorEdicionActionItem,
+  ContenedorBotonesActionItem,
+  ContenedorEdicionActionItem,
   ContenedorInputActionItem,
   InputActionItem,
 } from './ActionItemEditor.styled';
@@ -10,12 +12,21 @@ import Box from "@material-ui/core/Box";
 import Autocomplete from "@material-ui/lab/Autocomplete";
 import {TextField} from "@material-ui/core";
 import backend from '../api/backend'
+import Dialog from '@material-ui/core/Dialog';
+import Button from '@material-ui/core/Button';
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faTrash} from '@fortawesome/free-solid-svg-icons'
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
 
-const ActionItemEditor = ({onSubmit, itemDescription, itemOwners, estaEditando = false, alDescartar}) => {
+const ActionItemEditor = ({onSubmit, itemDescription, itemOwners, estaEditando = false, alDescartar, alBorrar}) => {
 
   const [descripcion, setDescripcion] = useState(itemDescription || '');
   const [owners, setOwners] = useState(itemOwners || []);
   const [usuarios, setUsuarios] = useState([])
+  const [confirmacionDeBorradoAbierta, setConfirmacionDeBorradoAbierta] = useState(false)
 
   const limpiarInputs = () => {
     setDescripcion('');
@@ -28,7 +39,7 @@ const ActionItemEditor = ({onSubmit, itemDescription, itemOwners, estaEditando =
   }
 
   const guardar = () => {
-    let actionItem = {descripcion, owners}
+      let actionItem = {descripcion, owners}
     if(esUnActionItemValido(actionItem)){
       onSubmit(actionItem);
       limpiarInputs();
@@ -53,38 +64,74 @@ const ActionItemEditor = ({onSubmit, itemDescription, itemOwners, estaEditando =
         setUsuarios(usuarios)})
   }
 
+  const abrirConfirmacionDeBorrado = () => {
+    setConfirmacionDeBorradoAbierta(true)
+  }
+
+  const cerrarConfirmacionDeBorrado = () => {
+    setConfirmacionDeBorradoAbierta(false)
+  }
+
+  const borrar = () => {
+    cerrarConfirmacionDeBorrado()
+    alBorrar({owners, descripcion})
+  }
+
   useEffect(actualizarUsuarios, [])
 
   return (
-    <Box component={ContenedorEdicionActionItem} clone boxShadow={2}>
-      <ContenedorEdicionActionItem maxWidth="md">
-        <ContenedorInputActionItem maxWidth="md">
-          <InputActionItem value={descripcion} onChange={(event) => setDescripcion(event.target.value)} multiline label="Descripción"/>
-          <Autocomplete
-            multiple
-            options={usuarios}
-            value={owners}
-            getOptionLabel={usuario => usuario.usuario}
-            renderOption={usuario => <div>{usuario.usuario} ({usuario.nombre})</div>}
-            onChange={(event, value) => setOwners(value)}
-            renderInput={params => (
-              <TextField {...params}
-              placeholder="Owners"
-              margin="normal"
-              fullWidth/>
-            )
-            }/>
-        </ContenedorInputActionItem>
-        <ContenedorBotonesActionItem>
-          <BotonCancelar onClick={descartar} variant="outlined">Descartar</BotonCancelar>
-          <BotonEnviar
-            size="small"
-            onClick={guardar}>
-              {estaEditando ? "Guardar" : "Crear action item"}
-          </BotonEnviar>
-        </ContenedorBotonesActionItem>
-      </ContenedorEdicionActionItem>
-    </Box>
+    <>
+      <Box component={ContenedorEdicionActionItem} clone boxShadow={2}>
+        <ContenedorEdicionActionItem maxWidth="md">
+          <ContenedorInputActionItem maxWidth="md">
+            <InputActionItem value={descripcion} onChange={(event) => setDescripcion(event.target.value)} multiline label="Descripción"/>
+            <Autocomplete
+              multiple
+              options={usuarios}
+              value={owners}
+              getOptionLabel={usuario => usuario.usuario}
+              renderOption={usuario => <div>{usuario.usuario} ({usuario.nombre})</div>}
+              onChange={(event, value) => setOwners(value)}
+              renderInput={params => (
+                <TextField {...params}
+                placeholder="Owners"
+                margin="normal"
+                fullWidth/> 
+              )
+              }/>
+          </ContenedorInputActionItem>
+          <ContenedorBotonesActionItem>
+            { estaEditando && <BotonBorrar variant="outlined" onClick={abrirConfirmacionDeBorrado}><FontAwesomeIcon icon={faTrash}/></BotonBorrar>}
+            <BotonCancelar onClick={descartar} variant="outlined">Descartar</BotonCancelar>
+            <BotonEnviar
+              size="small"
+              onClick={guardar}>
+                {estaEditando ? "Guardar" : "Crear action item"}
+            </BotonEnviar>
+          </ContenedorBotonesActionItem>
+        </ContenedorEdicionActionItem>
+      </Box>
+      <Dialog
+      open={confirmacionDeBorradoAbierta}
+      onClose={cerrarConfirmacionDeBorrado}
+      aria-labelledby="alert-dialog-slide-title"
+      aria-describedby="alert-dialog-slide-description">
+        <DialogTitle id="alert-dialog-slide-title">¿Querés borrar este Action Item?</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-slide-description">
+            Mirá que lo borramos ehh, lo borramos…
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={cerrarConfirmacionDeBorrado}>
+            Cancelar
+          </Button>
+          <Button onClick={borrar} color="secondary">
+            Borrar
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   )
 };
 

--- a/frontend/src/minuta/ActionItemEditor.js
+++ b/frontend/src/minuta/ActionItemEditor.js
@@ -1,9 +1,8 @@
-import React, {useState, useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import {
   BotonBorrar,
   BotonCancelar,
   BotonEnviar,
-  ContenedorBotonesActionItem,
   ContenedorEdicionActionItem,
   ContenedorInputActionItem,
   InputActionItem,
@@ -94,28 +93,21 @@ const ActionItemEditor = ({onSubmit, itemDescription, itemOwners, estaEditando =
               onChange={(event, value) => setOwners(value)}
               renderInput={params => (
                 <TextField {...params}
-                placeholder="Owners"
-                margin="normal"
-                fullWidth/>
+                           placeholder="Owners"
+                           margin="normal"
+                           fullWidth/>
               )
               }/>
           </ContenedorInputActionItem>
-          <ContenedorBotonesActionItem>
-            { estaEditando && <BotonBorrar variant="outlined" onClick={abrirConfirmacionDeBorrado}><FontAwesomeIcon icon={faTrash}/></BotonBorrar>}
-            <BotonCancelar onClick={descartar} variant="outlined">Descartar</BotonCancelar>
-            <BotonEnviar
-              size="small"
-              onClick={guardar}>
-                {estaEditando ? "Guardar" : "Crear action item"}
-            </BotonEnviar>
-          </ContenedorBotonesActionItem>
+          <Botonera estaEditando={estaEditando} onClick={abrirConfirmacionDeBorrado} onClick1={descartar}
+                    onClick2={guardar}/>
         </ContenedorEdicionActionItem>
       </Box>
       <Dialog
-      open={confirmacionDeBorradoAbierta}
-      onClose={cerrarConfirmacionDeBorrado}
-      aria-labelledby="alert-dialog-slide-title"
-      aria-describedby="alert-dialog-slide-description">
+        open={confirmacionDeBorradoAbierta}
+        onClose={cerrarConfirmacionDeBorrado}
+        aria-labelledby="alert-dialog-slide-title"
+        aria-describedby="alert-dialog-slide-description">
         <DialogTitle id="alert-dialog-slide-title">¿Querés borrar este Action Item?</DialogTitle>
         <DialogContent>
           <DialogContentText id="alert-dialog-slide-description">
@@ -134,5 +126,41 @@ const ActionItemEditor = ({onSubmit, itemDescription, itemOwners, estaEditando =
     </>
   )
 };
+
+function Botonera(props) {
+  
+   const BotonesBorrarYCancelar = (props) => (
+    <>
+       <BotonCancelar onClick={props.onClick1} variant="outlined">Descartar</BotonCancelar>
+       <BotonEnviar
+         size="small"
+         onClick={props.onClick2}>
+         {props.estaEditando ? "Guardar" : "Crear action item"}
+       </BotonEnviar>
+    </>
+  );
+  
+  return <Box display="flex" justifyContent="space-between">
+    {(props.estaEditando)?
+      <>
+        <BotonBorrar 
+          variant="outlined" 
+          onClick={props.onClick}
+        >
+          <FontAwesomeIcon icon={faTrash}/>
+        </BotonBorrar>
+        <Box 
+          display="flex" 
+          justifyContent= "space-between"
+          width="0.4"
+        >
+          <BotonesBorrarYCancelar {...props}/>
+        </Box>
+      </>
+      :
+      <BotonesBorrarYCancelar {...props}/>
+    }
+  </Box>;
+}
 
 export { ActionItemEditor };

--- a/frontend/src/minuta/ActionItemEditor.js
+++ b/frontend/src/minuta/ActionItemEditor.js
@@ -39,7 +39,7 @@ const ActionItemEditor = ({onSubmit, itemDescription, itemOwners, estaEditando =
   }
 
   const guardar = () => {
-      let actionItem = {descripcion, owners}
+    let actionItem = {descripcion, owners}
     if(esUnActionItemValido(actionItem)){
       onSubmit(actionItem);
       limpiarInputs();
@@ -96,7 +96,7 @@ const ActionItemEditor = ({onSubmit, itemDescription, itemOwners, estaEditando =
                 <TextField {...params}
                 placeholder="Owners"
                 margin="normal"
-                fullWidth/> 
+                fullWidth/>
               )
               }/>
           </ContenedorInputActionItem>

--- a/frontend/src/minuta/ActionItemEditor.styled.js
+++ b/frontend/src/minuta/ActionItemEditor.styled.js
@@ -3,17 +3,18 @@ import styled from 'styled-components';
 import {Button, Container, makeStyles, TextField} from '@material-ui/core';
 import {colors} from '../styles/theme';
 
-export const ContenedorEdicionActionItem = styled(Container)`
+export const ContenedorEdicionActionItem = styled.div`
   background-color: #C7F0E6;
   display: flex;
   flex-direction: column;
+  padding:1.5vw;
+  width:inherit;
 `;
 
 const boton = (theme) => ({
     fontFamily: 'Poppins',
     fontWeight: "bold",
-    margin: `${theme.spacing(1.5)}px 0px ${theme.spacing(1.5)}px 0px`,
-    padding: `${theme.spacing(0.5)}px ${theme.spacing(1)}px ${theme.spacing(0.5)}px ${theme.spacing(1)}px`,
+    margin: `0px ${theme.spacing(1.5)}px`,
 });
 
 const useStylesBotones = makeStyles(theme => ({
@@ -23,9 +24,19 @@ const useStylesBotones = makeStyles(theme => ({
   botonEnviar: {
     ...boton(theme),
     backgroundColor: colors.primary,
-    color: colors.white
+    color: colors.white,
+  },
+  BotonBorrar:{
+    minWidth: '0px',
+    marginRight: 'auto',
+    color:`${colors.black50}` 
   }
 }));
+
+export function BotonBorrar(props) {
+  const classes = useStylesBotones();
+  return <Button {...props} className={classes.BotonBorrar}>{props.children}</Button>;
+}
 
 export function BotonCancelar(props) {
   const classes = useStylesBotones();
@@ -41,12 +52,10 @@ const useStylesContenedorActionItems = makeStyles(theme => ({
   root: {
     backgroundColor: colors.white,
     padding: theme.spacing(3),
-    marginTop: theme.spacing(3),
     display: "flex",
     flexDirection: "column"
   }
 }));
-
 
 export function ContenedorInputActionItem(props) {
   const classes = useStylesContenedorActionItems();
@@ -75,5 +84,6 @@ export const InputActionItem = (props) => {
 export const ContenedorBotonesActionItem = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: flex-end;
+  margin-top: 20px;
 `;

--- a/frontend/src/minuta/ActionItemEditor.styled.js
+++ b/frontend/src/minuta/ActionItemEditor.styled.js
@@ -3,18 +3,18 @@ import styled from 'styled-components';
 import {Button, Container, makeStyles, TextField} from '@material-ui/core';
 import {colors} from '../styles/theme';
 
-export const ContenedorEdicionActionItem = styled.div`
+export const ContenedorEdicionActionItem = styled(Container)`
   background-color: #C7F0E6;
   display: flex;
   flex-direction: column;
-  padding:1.5vw;
-  width:inherit;
 `;
 
 const boton = (theme) => ({
     fontFamily: 'Poppins',
     fontWeight: "bold",
-    margin: `0px ${theme.spacing(1.5)}px`,
+    margin: `${theme.spacing(1.5)}px 0px ${theme.spacing(1.5)}px 0px`,
+    padding: `${theme.spacing(0.5)}px ${theme.spacing(1)}px ${theme.spacing(0.5)}px ${theme.spacing(1)}px`,
+    letterSpacing: '1px'
 });
 
 const useStylesBotones = makeStyles(theme => ({
@@ -27,8 +27,8 @@ const useStylesBotones = makeStyles(theme => ({
     color: colors.white,
   },
   BotonBorrar:{
-    minWidth: '0px',
-    marginRight: 'auto',
+    ...boton(theme),
+    minWidth: 0,
     color:`${colors.black50}` 
   }
 }));
@@ -52,6 +52,7 @@ const useStylesContenedorActionItems = makeStyles(theme => ({
   root: {
     backgroundColor: colors.white,
     padding: theme.spacing(3),
+    marginTop: theme.spacing(3),
     display: "flex",
     flexDirection: "column"
   }
@@ -81,10 +82,3 @@ export const InputActionItem = (props) => {
     <TextField classes={useStyles()} {...props}/>
   );
 };
-
-export const ContenedorBotonesActionItem = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  margin-top: 20px;
-`;

--- a/frontend/src/minuta/ActionItemEditor.styled.js
+++ b/frontend/src/minuta/ActionItemEditor.styled.js
@@ -57,6 +57,7 @@ const useStylesContenedorActionItems = makeStyles(theme => ({
   }
 }));
 
+
 export function ContenedorInputActionItem(props) {
   const classes = useStylesContenedorActionItems();
   return <Container {...props} className={classes.root}>{props.children}</Container>;

--- a/frontend/src/minuta/ListaActionItems.js
+++ b/frontend/src/minuta/ListaActionItems.js
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {Divider, List, ListItem, makeStyles} from '@material-ui/core';
+import {List, ListItem, Divider, makeStyles} from '@material-ui/core';
 import {ActionItemContainer, ActionItemDescription, ListaActionItemsContainer, Owner} from './ListaActionItems.styled'
 import {ActionItemEditor} from "./ActionItemEditor";
 

--- a/frontend/src/minuta/ListaActionItems.js
+++ b/frontend/src/minuta/ListaActionItems.js
@@ -1,14 +1,20 @@
 import React, {useState} from 'react';
-import {List, ListItem, Divider, makeStyles} from '@material-ui/core';
+import {Divider, List, ListItem, makeStyles} from '@material-ui/core';
 import {ActionItemContainer, ActionItemDescription, ListaActionItemsContainer, Owner} from './ListaActionItems.styled'
 import {ActionItemEditor} from "./ActionItemEditor";
 
-const ActionItem = ({descripcion, owners, onEdit, id}) =>{
+const ActionItem = ({descripcion, owners, onEdit, onDelete, id}) =>{
   const [estaEditando, setEstaEditando] = useState(false);
 
+  const actionItemConId = (actionItem) => { return {...actionItem, id}}
+
   const alGuardarEdicion = (actionItemGuardado) => {
-    onEdit({...actionItemGuardado, id})
+    onEdit(actionItemConId(actionItemGuardado))
     setEstaEditando(false)
+  }
+
+  const alBorrarActionItem = (actionItemABorrar) => {
+    onDelete(actionItemConId(actionItemABorrar))
   }
 
   const itemClass = {
@@ -34,6 +40,7 @@ const ActionItem = ({descripcion, owners, onEdit, id}) =>{
           itemOwners={owners}
           estaEditando={estaEditando}
           alDescartar={()=>{setEstaEditando(false)}}
+          alBorrar={alBorrarActionItem}
           onSubmit={alGuardarEdicion}
         />
       }
@@ -41,7 +48,7 @@ const ActionItem = ({descripcion, owners, onEdit, id}) =>{
   )
 }
 
-export const ListaActionItems = ({actionItems, onEdit}) => {
+export const ListaActionItems = ({actionItems, onEdit, alBorrar}) => {
   
   function esElUltimoItem(index) {
     return actionItems.length === index + 1;
@@ -67,6 +74,7 @@ export const ListaActionItems = ({actionItems, onEdit}) => {
                   descripcion={item.actionItem.descripcion} 
                   owners={item.actionItem.owners}
                   onEdit={onEdit}
+                  onDelete={alBorrar}
                 />
                 {!esElUltimoItem(index) && <Divider/>}
               </>

--- a/frontend/src/store/__tests__/actionItem.test.js
+++ b/frontend/src/store/__tests__/actionItem.test.js
@@ -31,6 +31,7 @@ describe(`# action items!`, () => {
     const actionItem = {
       descripcion: 'Jugar al truco',
       owners: ['Lautaro'],
+      id:0
     };
     applyEvento(eventoAgregarActionItem(actionItem));
     expect(state[0].actionItem.descripcion).toEqual(actionItem.descripcion);
@@ -51,6 +52,7 @@ describe(`# action items!`, () => {
     const actionItemAgregado = {
       descripcion: 'Jugar a la play',
       owners: ['Lautaro'],
+      id:0
     };
 
     beforeEach(() => {

--- a/frontend/src/store/actionItem.js
+++ b/frontend/src/store/actionItem.js
@@ -1,8 +1,9 @@
-import { produce } from 'immer';
+import {produce} from 'immer';
 
 export const tipoDeEvento = {
   AGREGAR_ACTION_ITEM: 'Agregar un action item',
   EDITAR_ACTION_ITEM: 'Editar un action item',
+  BORRAR_ACTION_ITEM: 'Borrar action item'
 };
 
 export const INITIAL_ACTION_ITEMS_STATE = [];
@@ -16,6 +17,12 @@ export const actionItemReducer = (state = INITIAL_ACTION_ITEMS_STATE, evento) =>
       let indexDeActionItemAEditar = prevActionItems.findIndex((actionItem) => actionItem.id === evento.actionItem.id)
       if(prevActionItems[indexDeActionItemAEditar]){
         prevActionItems[indexDeActionItemAEditar] = evento
+      }
+      break;
+    case (tipoDeEvento.BORRAR_ACTION_ITEM):
+      let indexDeActionItemABorrar = prevActionItems.findIndex(actionItem =>actionItem.id === evento.actionItem.id)
+      if(indexDeActionItemABorrar>=0){
+        prevActionItems.splice(indexDeActionItemABorrar, 1)
       }
       break;
     default:

--- a/frontend/src/store/actionItem.js
+++ b/frontend/src/store/actionItem.js
@@ -1,4 +1,4 @@
-import {produce} from 'immer';
+import { produce } from 'immer';
 
 export const tipoDeEvento = {
   AGREGAR_ACTION_ITEM: 'Agregar un action item',

--- a/frontend/src/tipos-vista-principal/Minuta.js
+++ b/frontend/src/tipos-vista-principal/Minuta.js
@@ -1,18 +1,18 @@
-import React, { useState, useEffect } from "react";
+import React, {useEffect, useState} from "react";
 import {VistaDelMedioContainer, VistaMinutaContainer} from "./Resumen.styled";
-import { useSpring } from "react-spring";
-import { connect } from "react-redux";
-import { tipoDeEvento } from "../store/conclusion";
-import { tipoDeEvento as tipoDeEventoOradores} from "../store/oradores";
-import { tipoDeEvento as tipoDeEventoActionItem} from "../store/actionItem";
-import { toast } from "react-toastify";
+import {useSpring} from "react-spring";
+import {connect} from "react-redux";
+import {tipoDeEvento} from "../store/conclusion";
+import {tipoDeEvento as tipoDeEventoOradores} from "../store/oradores";
+import {tipoDeEvento as tipoDeEventoActionItem} from "../store/actionItem";
+import {toast} from "react-toastify";
 import TablaOradores from "../minuta/TablaOradores";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faChevronDown} from "@fortawesome/free-solid-svg-icons/faChevronDown";
-import {BotonParaAbrirResumen, TabRenderer, TabsHeader, CustomTab} from "../minuta/Minuta.styled";
+import {BotonParaAbrirResumen, CustomTab, TabRenderer, TabsHeader} from "../minuta/Minuta.styled";
 import Collapse from '@material-ui/core/Collapse';
-import { ActionItemEditor } from "../minuta/ActionItemEditor";
-import { ResumenOrador } from "../minuta/ResumenOrador";
+import {ActionItemEditor} from "../minuta/ActionItemEditor";
+import {ResumenOrador} from "../minuta/ResumenOrador";
 import {ListaActionItems} from "../minuta/ListaActionItems"
 import {ConclusionTema} from "../minuta/ConclusionTema";
 import Grid from "@material-ui/core/Grid";
@@ -136,6 +136,13 @@ const Minuta = ({ dispatch, tema }) => {
     })
   }
 
+  const borrarActionItem = (actionItem) => {
+    crearEventoDeMinuteador({
+      tipo: tipoDeEventoActionItem.BORRAR_ACTION_ITEM,
+      actionItem
+    })
+  }
+
   const textoBotonEdicion = () => (isResumenOradorCerrado ? 'CERRAR EDICION' : 'ABRIR EDICION');
 
   return (
@@ -193,7 +200,7 @@ const Minuta = ({ dispatch, tema }) => {
             <Grid item xs={7}>
               <h1>Action Items ({tema.actionItems.length})</h1>
               <ActionItemEditor onSubmit={agregarActionItem}/>
-              <ListaActionItems actionItems={tema.actionItems} onEdit={editarActionItem} />
+              <ListaActionItems actionItems={tema.actionItems} alBorrar={borrarActionItem} onEdit={editarActionItem} />
             </Grid>
           </Grid>
         </TabRenderer>

--- a/frontend/src/tipos-vista-principal/Minuta.js
+++ b/frontend/src/tipos-vista-principal/Minuta.js
@@ -9,7 +9,7 @@ import { toast } from "react-toastify";
 import TablaOradores from "../minuta/TablaOradores";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faChevronDown} from "@fortawesome/free-solid-svg-icons/faChevronDown";
-import {BotonParaAbrirResumen, CustomTab, TabRenderer, TabsHeader} from "../minuta/Minuta.styled";
+import {BotonParaAbrirResumen, TabRenderer, TabsHeader, CustomTab} from "../minuta/Minuta.styled";
 import Collapse from '@material-ui/core/Collapse';
 import { ActionItemEditor } from "../minuta/ActionItemEditor";
 import { ResumenOrador } from "../minuta/ResumenOrador";

--- a/frontend/src/tipos-vista-principal/Minuta.js
+++ b/frontend/src/tipos-vista-principal/Minuta.js
@@ -1,18 +1,18 @@
-import React, {useEffect, useState} from "react";
+import React, { useState, useEffect } from "react";
 import {VistaDelMedioContainer, VistaMinutaContainer} from "./Resumen.styled";
-import {useSpring} from "react-spring";
-import {connect} from "react-redux";
-import {tipoDeEvento} from "../store/conclusion";
-import {tipoDeEvento as tipoDeEventoOradores} from "../store/oradores";
-import {tipoDeEvento as tipoDeEventoActionItem} from "../store/actionItem";
-import {toast} from "react-toastify";
+import { useSpring } from "react-spring";
+import { connect } from "react-redux";
+import { tipoDeEvento } from "../store/conclusion";
+import { tipoDeEvento as tipoDeEventoOradores} from "../store/oradores";
+import { tipoDeEvento as tipoDeEventoActionItem} from "../store/actionItem";
+import { toast } from "react-toastify";
 import TablaOradores from "../minuta/TablaOradores";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faChevronDown} from "@fortawesome/free-solid-svg-icons/faChevronDown";
 import {BotonParaAbrirResumen, CustomTab, TabRenderer, TabsHeader} from "../minuta/Minuta.styled";
 import Collapse from '@material-ui/core/Collapse';
-import {ActionItemEditor} from "../minuta/ActionItemEditor";
-import {ResumenOrador} from "../minuta/ResumenOrador";
+import { ActionItemEditor } from "../minuta/ActionItemEditor";
+import { ResumenOrador } from "../minuta/ResumenOrador";
 import {ListaActionItems} from "../minuta/ListaActionItems"
 import {ConclusionTema} from "../minuta/ConclusionTema";
 import Grid from "@material-ui/core/Grid";


### PR DESCRIPTION

![borrar-action-items](https://user-images.githubusercontent.com/34402401/87471479-cec60f00-c5f4-11ea-965a-c7c9a087c6ec.gif)

Juro que el color del boton borrar es rojo pero el coso de gif no lo agarra. 
El PR queda en draft hasta que se actualize el header del sitio ya que al estar en posicion absoluta tapa todo el contenido como se puede ver en el gif. Cualquier comentario es apreciado

-Se agrego el evento borrar acition item
-se hizo refactor de la ui del editor de action item

se cambia el texto del dialogo

fix: abrir y cerrar el modal no genera scroll automatico en la pagina

fix: se borraba solo el primero

revision de codigo

[**Link al Trello**](https://trello.com/c/ID_DE_LA_CARD)

**Aceptación**
(Acá van imagenes o una descipción de qué valor agrega este PR)

**Checklist**:
- [x] Agregue tests (y los corrí localmente)
- [x] Vi que localmente funcionara
- [ ] Probe que en la review app funcionara

