### PR TITLE
fix sidebar tapa titulos largos

### DIFF
--- a/frontend/src/reunion/Header.styled.js
+++ b/frontend/src/reunion/Header.styled.js
@@ -18,5 +18,6 @@ export const Titulo = styled.h1`
   text-overflow:ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  margin-left:1.4em;
 `;
 


### PR DESCRIPTION
[**Link al Trello**](https://trello.com/c/xNAChz1a/188-ajustar-t%C3%ADtulo-de-tema-en-pantalla-de-resumen-para-que-no-quede-debajo-de-la-sidebar-de-temario)

**Aceptación**
antes
![image](https://user-images.githubusercontent.com/24365725/88724651-415ce180-d101-11ea-9970-e9fd5d5c59e4.png)

despues
![image](https://user-images.githubusercontent.com/24365725/88724533-0fe41600-d101-11ea-9cd1-ebdc1cb9d0c2.png)


