### PR TITLE
Refactor como se guardan los eventos en la db

### DIFF
--- a/backend/src/database/migrations/20200818184925-renombrar-columna-temaId-a-idTema-en-tabla-Eventos.js
+++ b/backend/src/database/migrations/20200818184925-renombrar-columna-temaId-a-idTema-en-tabla-Eventos.js
@@ -1,0 +1,10 @@
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn('Eventos', 'temaId', 'idTema');
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn('Eventos', 'idTema', 'temaId');
+  },
+};

--- a/backend/src/database/migrations/20200818190740-agregar-fk-de-tema-a-eventos.js
+++ b/backend/src/database/migrations/20200818190740-agregar-fk-de-tema-a-eventos.js
@@ -1,0 +1,24 @@
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn(
+      'Eventos',
+      'idTema',
+      {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Temas',
+          key: 'id',
+        },
+      },
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn(
+      'Eventos',
+      'idTema',
+      { },
+    );
+  },
+};

--- a/backend/src/database/models/evento.js
+++ b/backend/src/database/models/evento.js
@@ -4,7 +4,7 @@ module.exports = (sequelize, DataTypes) => {
   }, {});
 
   Evento.associate = (models) => {
-    Evento.Tema = Evento.belongsTo(models.Tema, { foreignKey: 'temaId' });
+    Evento.Tema = Evento.belongsTo(models.Tema, { foreignKey: 'idTema' });
     Evento.Reunion = Evento.belongsTo(models.Reunion, { foreignKey: 'reunionId' });
   };
 

--- a/backend/src/domain/eventos/controller.js
+++ b/backend/src/domain/eventos/controller.js
@@ -8,6 +8,10 @@ const Controller = (wss) => {
     publicar: async (req, res) => {
       await lock.acquire('event', async () => {
         const eventoRaw = req.body;
+        const { idTema, reunionId } = eventoRaw;
+
+        delete eventoRaw.idTema;
+        delete eventoRaw.reunionId;
 
         const contenidoEvento = {
           ...eventoRaw,
@@ -16,8 +20,8 @@ const Controller = (wss) => {
 
         const eventoNuevo = await context.eventosRepo.guardarEvento({
           evento: contenidoEvento,
-          idTema: eventoRaw.idTema,
-          reunionId: eventoRaw.reunionId,
+          idTema,
+          reunionId,
         });
 
         res.status(200)
@@ -27,6 +31,8 @@ const Controller = (wss) => {
           client.send(JSON.stringify([{
             ...eventoNuevo.evento,
             id: eventoNuevo.id,
+            reunionId,
+            idTema,
           }]));
         });
       });

--- a/backend/src/domain/eventos/repo.js
+++ b/backend/src/domain/eventos/repo.js
@@ -18,7 +18,7 @@ export default class EventosRepo {
     return models.Evento.findAll({ where: whereClause, order: [['id', 'ASC']] });
   }
 
-  guardarEvento({ evento, temaId, reunionId }) {
-    return models.Evento.create({ evento, temaId, reunionId });
+  guardarEvento({ evento, idTema, reunionId }) {
+    return models.Evento.create({ evento, idTema, reunionId });
   }
 }


### PR DESCRIPTION
[**Link al Trello**](https://trello.com/c/BCrOvGdQ/196-idtema-en-en-la-base-de-datos-esta-vacio)

Actualmente se guardan todos los idTema en nulo dentro de la tabla eventos. Esto se cambia con la migracion.
Yapa se borran reunionId y temaId del evetno para evitar la reduncancia de datos ya que tienen sus propias columnas.

