### PR TITLE
Fix: al cerrar un tema con un orador hablando rompe el timepo

### DIFF
--- a/frontend/src/store/oradores.js
+++ b/frontend/src/store/oradores.js
@@ -50,6 +50,15 @@ export const INITIAL_ORADORES_STATE = {
   cola: [],
 };
 
+export const oradorAcciones = {
+  detenerOradorActual: (draft, fecha) => {
+      const oradorActual = draft.actual;
+      oradorActual.fin = fecha;
+      draft.pasados.push(oradorActual);
+      draft.actual = null;
+  }
+}
+
 export const oradoresReducer = (state = INITIAL_ORADORES_STATE, evento) =>
 produce(state, (draft) => {
   const { usuario, fecha } = evento;
@@ -58,13 +67,11 @@ produce(state, (draft) => {
       if (!estaHablando(draft, evento.kickearA.nombre)) {
         return;
       }
-      const oradorActual = draft.actual;
-      oradorActual.fin = fecha;
-      draft.pasados.push(oradorActual);
+      
+      oradorAcciones.detenerOradorActual(draft, fecha)
 
       const nextOrador = draft.cola.shift();
       if (!nextOrador) {
-        draft.actual = null;
         return;
       }
 
@@ -107,13 +114,11 @@ produce(state, (draft) => {
       if (!estaHablando(draft, usuario.nombre)) {
         return;
       }
-      const oradorActual = draft.actual;
-      oradorActual.fin = fecha;
-      draft.pasados.push(oradorActual);
+
+      oradorAcciones.detenerOradorActual(draft, fecha)
 
       const nextOrador = draft.cola.shift();
       if (!nextOrador) {
-        draft.actual = null;
         return;
       }
 

--- a/frontend/src/store/tema.js
+++ b/frontend/src/store/tema.js
@@ -5,6 +5,7 @@ import { actionItemReducer } from "./actionItem";
 import { reaccionesReducer } from "./reacciones";
 import { historicoDeReaccionesReducer } from "./historicoDeReacciones";
 import { createEvent } from "./evento";
+import { oradorAcciones } from "./oradores"
 
 export const temaEventoTypes = {
   EMPEZAR_TEMA: "Se le da comienzo a un tema",
@@ -40,9 +41,14 @@ export const temaReducer = (state = INITIAL_TEMA_STATE, action) =>
 
       case temaEventoTypes.TERMINAR_TEMA: {
         const ahora = new Date(action.fecha).toISOString();
-        if (draft.fin === null && draft.inicio !== null) {
-          draft.fin = ahora;
-        }
+
+        if (draft.fin !== null || draft.inicio === null)
+          return;
+
+        draft.fin = ahora;
+        if(draft.oradores.actual)
+          oradorAcciones.detenerOradorActual(draft.oradores, action.fecha)
+        
         break;
       }
 


### PR DESCRIPTION
[**Link al Trello**](https://trello.com/c/jT6GSEgm/203-cuando-se-cierra-tema-y-hay-alguien-hablando-el-tiempo-que-queda-registrado-que-hablo-el-ultimo-orador-es-erratico)

Cuando se cerraba un tema y habia alguien hablando el tiempo de ese orador quedaba en algo asi como 2 millones. Este Pr lo soluciona

