### PR TITLE
Conectar botones reunion cerrada

### DIFF
--- a/backend/src/domain/eventos/controller.js
+++ b/backend/src/domain/eventos/controller.js
@@ -11,7 +11,8 @@ const Controller = (wss) => {
       const { reunionId } = eventoRaw;
       const reunion = await context.reunionesRepo.findOneById(reunionId);
       const eventoPermitido = 'La reunion fue finalizada';
-      const reunionCerradaYEventoNoPermitido = !reunion.abierta && eventoRaw.type !== eventoPermitido;
+      const reunionCerradaYEventoNoPermitido = !reunion.abierta
+          && eventoRaw.type !== eventoPermitido;
 
       if (reunionCerradaYEventoNoPermitido) {
         throw new RequestError(400, 'La reunion está cerrada');

--- a/backend/src/domain/eventos/controller.js
+++ b/backend/src/domain/eventos/controller.js
@@ -10,9 +10,10 @@ const Controller = (wss) => {
       const eventoRaw = req.body;
       const { reunionId } = eventoRaw;
       const reunion = await context.reunionesRepo.findOneById(reunionId);
-      console.log('Estado de la reunion');
-      console.log(reunion.abierta);
-      if (!reunion.abierta && eventoRaw.type !== 'La reunion fue finalizada') {
+      const eventoPermitido = 'La reunion fue finalizada';
+      const reunionCerradaYEventoNoPermitido = !reunion.abierta && eventoRaw.type !== eventoPermitido;
+
+      if (reunionCerradaYEventoNoPermitido) {
         throw new RequestError(400, 'La reunion está cerrada');
       }
       await lock.acquire(`event/${reunionId}`, async () => {

--- a/backend/src/domain/eventos/controller.js
+++ b/backend/src/domain/eventos/controller.js
@@ -1,5 +1,6 @@
 import AsyncLock from 'async-lock';
 import context from '~/context';
+import { RequestError } from '../../utils/asyncMiddleware';
 
 const Controller = (wss) => {
   const lock = new AsyncLock();
@@ -8,7 +9,12 @@ const Controller = (wss) => {
     publicar: async (req, res) => {
       const eventoRaw = req.body;
       const { reunionId } = eventoRaw;
-
+      const reunion = await context.reunionesRepo.findOneById(reunionId);
+      console.log('Estado de la reunion');
+      console.log(reunion.abierta);
+      if (!reunion.abierta && eventoRaw.type !== 'La reunion fue finalizada') {
+        throw new RequestError(400, 'La reunion está cerrada');
+      }
       await lock.acquire(`event/${reunionId}`, async () => {
         const contenidoEvento = {
           ...eventoRaw,

--- a/backend/src/domain/eventos/eventos.test.js
+++ b/backend/src/domain/eventos/eventos.test.js
@@ -42,9 +42,10 @@ describe('si una reunión está cerrada ', () => {
 
   describe('y se quiere publicar un evento diferente al de cerrar reunión', () => {
     test('no debería poder hacerlo', async () => {
+      const tipoEventoNoPermitido = 'Reaccionar';
       const eventoReaccionar = {
         reunionId: reunionCerrada.id,
-        type: 'Reaccionar',
+        type: tipoEventoNoPermitido,
         idTema: 44,
         nombre: '👍',
         usuario: { nombre: 'Pine Buena Onda', email: 'pine.buenaonda@10pines.com' },
@@ -57,9 +58,10 @@ describe('si una reunión está cerrada ', () => {
   });
   describe('y se quiere publicar un evento diferente de cerrar reunión', () => {
     test('debería poder hacerlo', async () => {
+      const tipoEventoPermitido = 'La reunion fue finalizada';
       const eventoReaccionar = {
         reunionId: reunionCerrada.id,
-        type: 'La reunion fue finalizada',
+        type: tipoEventoPermitido,
       };
 
       const response = await request(app).post('/api/eventos').send(eventoReaccionar);

--- a/backend/src/domain/eventos/eventos.test.js
+++ b/backend/src/domain/eventos/eventos.test.js
@@ -50,13 +50,18 @@ describe('si una reunión está cerrada ', () => {
         nombre: '👍',
         usuario: { nombre: 'Pine Buena Onda', email: 'pine.buenaonda@10pines.com' },
       };
+      const temasDeReunionAntes = await
+      eventosRepo.findEventosParaReunion(undefined, reunionCerrada.id);
 
       const response = await request(app).post('/api/eventos').send(eventoReaccionar);
+      const temasDeReunionDespues = await
+      eventosRepo.findEventosParaReunion(undefined, reunionCerrada.id);
 
       expect(response.status).toEqual(400);
+      expect(temasDeReunionAntes).toEqual(temasDeReunionDespues);
     });
   });
-  describe('y se quiere publicar un evento diferente de cerrar reunión', () => {
+  describe('y se quiere publicar un evento de cerrar reunión', () => {
     test('debería poder hacerlo', async () => {
       const tipoEventoPermitido = 'La reunion fue finalizada';
       const eventoReaccionar = {

--- a/backend/src/domain/eventos/eventos.test.js
+++ b/backend/src/domain/eventos/eventos.test.js
@@ -1,0 +1,70 @@
+import request from 'supertest';
+import { response } from 'express';
+import ReunionesRepo from '~/domain/reuniones/repo';
+import app from '~/server';
+import db from '~/database/models';
+import TemasRepo from '~/domain/temas/repo';
+import EventosRepo from '~/domain/eventos/repo';
+
+jest.mock('../login/estaLogueado', () => () => true);
+
+const temaGenerico = {
+  autor: 'Ailen Muñoz',
+  cantidadDeMinutosDelTema: 60,
+  descripcion: ':)',
+  duracion: 'MEDIO',
+  linkDePresentacion: null,
+  mailDelAutor: null,
+  obligatoriedad: 'OBLIGATORIO',
+  prioridad: 2,
+  propuestas: null,
+  temasParaRepasar: null,
+  tipo: 'conDescripcion',
+  titulo: 'HOla hola',
+};
+
+
+describe('si una reunión está cerrada ', () => {
+  let reunionesRepo;
+  let reunionCerrada;
+  let eventosRepo;
+  let temasRepo;
+  let temasGuardadosCerrada;
+
+  beforeEach(async () => {
+    await db.sequelize.sync({ force: true });
+    reunionesRepo = new ReunionesRepo();
+    reunionCerrada = await reunionesRepo.create({ abierta: false, nombre: 'reunionCerrada' });
+    temasRepo = new TemasRepo();
+    temasGuardadosCerrada = await temasRepo.guardarTemas(reunionCerrada, [temaGenerico]);
+    eventosRepo = new EventosRepo();
+  });
+
+  describe('y se quiere publicar un evento diferente al de cerrar reunión', () => {
+    test('no debería poder hacerlo', async () => {
+      const eventoReaccionar = {
+        reunionId: reunionCerrada.id,
+        type: 'Reaccionar',
+        idTema: 44,
+        nombre: '👍',
+        usuario: { nombre: 'Pine Buena Onda', email: 'pine.buenaonda@10pines.com' },
+      };
+
+      const response = await request(app).post('/api/eventos').send(eventoReaccionar);
+
+      expect(response.status).toEqual(400);
+    });
+  });
+  describe('y se quiere publicar un evento diferente de cerrar reunión', () => {
+    test('debería poder hacerlo', async () => {
+      const eventoReaccionar = {
+        reunionId: reunionCerrada.id,
+        type: 'La reunion fue finalizada',
+      };
+
+      const response = await request(app).post('/api/eventos').send(eventoReaccionar);
+
+      expect(response.status).toEqual(200);
+    });
+  });
+});

--- a/backend/src/domain/reuniones/controller.js
+++ b/backend/src/domain/reuniones/controller.js
@@ -1,6 +1,7 @@
 import VotacionDeRoots from '../votacionDeRoots/votacionDeRoots';
 import enviarResumenPorMail from '~/domain/mail/mail';
 import notificador from './notificador';
+import { RequestError } from '~/utils/asyncMiddleware';
 
 function validarReunionRapida(req) {
   const { tema, autor, nombre } = req.body;
@@ -62,6 +63,9 @@ const ReunionController = ({ reunionesRepo: repoReuniones, temasRepo: repoTemas 
   actualizar: async (req) => {
     const { abierta, temas, id } = req.body;
     const reunionAActualizar = await repoReuniones.findOneById(id);
+    if (!reunionAActualizar.abierta) {
+      throw new RequestError(403, 'No se puede actualizar una reunion cerrada');
+    }
     await reunionAActualizar.update({ abierta });
 
     if (!abierta) {

--- a/backend/src/domain/reuniones/controller.js
+++ b/backend/src/domain/reuniones/controller.js
@@ -6,7 +6,7 @@ import { RequestError } from '~/utils/asyncMiddleware';
 function validarReunionRapida(req) {
   const { tema, autor, nombre } = req.body;
   if (tema === '' || nombre === '' || autor === '') {
-    throw new Error('Faltan campos en la reunion');
+    throw new RequestError(400, 'Faltan campos en la reunion');
   }
 }
 

--- a/backend/src/domain/reuniones/controller.js
+++ b/backend/src/domain/reuniones/controller.js
@@ -64,7 +64,7 @@ const ReunionController = ({ reunionesRepo: repoReuniones, temasRepo: repoTemas 
     const { abierta, temas, id } = req.body;
     const reunionAActualizar = await repoReuniones.findOneById(id);
     if (!reunionAActualizar.abierta) {
-      throw new RequestError(403, 'No se puede actualizar una reunion cerrada');
+      throw new RequestError(400, 'No se puede actualizar una reunion cerrada');
     }
     await reunionAActualizar.update({ abierta });
 

--- a/backend/src/domain/reuniones/reuniones.test.js
+++ b/backend/src/domain/reuniones/reuniones.test.js
@@ -59,6 +59,18 @@ describe('para reuniones', () => {
       expect(response.statusCode).toEqual(200);
       expect(response.body.reuniones).toEqual([]);
     });
+
+    test('y se intenta actualizar alguna debería fallar', async () => {
+      reunionesRepo = new ReunionesRepo();
+      repoTemas = new TemasRepo();
+      reunionCerrada = await reunionesRepo.create({ abierta: false, nombre: 'reunionCerrada' });
+      temasGuardadosCerrada = await repoTemas.guardarTemas(reunionCerrada, [temaGenerico]);
+      const requestBody = { abierta: reunionCerrada.abierta, id: reunionCerrada.id, temas: temasGuardadosCerrada };
+
+      const response = await request(app).put('/api/reunion').send(requestBody);
+
+      expect(response.status).toEqual(403);
+    });
   });
 
 

--- a/backend/src/domain/reuniones/reuniones.test.js
+++ b/backend/src/domain/reuniones/reuniones.test.js
@@ -69,7 +69,7 @@ describe('para reuniones', () => {
 
       const response = await request(app).put('/api/reunion').send(requestBody);
 
-      expect(response.status).toEqual(403);
+      expect(response.status).toEqual(400);
     });
   });
 

--- a/backend/src/utils/asyncMiddleware.js
+++ b/backend/src/utils/asyncMiddleware.js
@@ -1,9 +1,22 @@
-const asyncMiddleware = (fn) => (req, res, next) => Promise.resolve(fn(req, res, next))
-  .then((data) => respondWithSuccess(res, data))
-  .catch(next);
-
-export default asyncMiddleware;
-
+export class RequestError {
+  constructor(statusCode, errorMessage) {
+    this.statusCode = statusCode;
+    this.errorMessage = errorMessage;
+  }
+}
 const respondWithSuccess = (res, data) => {
   res.status(200).send(data);
 };
+
+
+const asyncMiddleware = (fn) => (req, res) => Promise.resolve(fn(req, res))
+  .then((data) => respondWithSuccess(res, data))
+  .catch((error) => {
+    if (error instanceof RequestError) {
+      res.status(error.statusCode).send(error.errorMessage);
+    } else {
+      throw error;
+    }
+  });
+
+export default asyncMiddleware;

--- a/backend/src/utils/asyncMiddleware.js
+++ b/backend/src/utils/asyncMiddleware.js
@@ -9,7 +9,7 @@ const respondWithSuccess = (res, data) => {
 };
 
 
-const asyncMiddleware = (fn) => (req, res) => Promise.resolve(fn(req, res, next))
+const asyncMiddleware = (fn) => (req, res, next) => Promise.resolve(fn(req, res, next))
   .then((data) => respondWithSuccess(res, data))
   .catch((error) => {
     if (error instanceof RequestError) {

--- a/backend/src/utils/asyncMiddleware.js
+++ b/backend/src/utils/asyncMiddleware.js
@@ -15,7 +15,7 @@ const asyncMiddleware = (fn) => (req, res) => Promise.resolve(fn(req, res))
     if (error instanceof RequestError) {
       res.status(error.statusCode).send(error.errorMessage);
     } else {
-      throw error;
+      res.status(500).send('Request fallo');
     }
   });
 

--- a/backend/src/utils/asyncMiddleware.js
+++ b/backend/src/utils/asyncMiddleware.js
@@ -9,13 +9,13 @@ const respondWithSuccess = (res, data) => {
 };
 
 
-const asyncMiddleware = (fn) => (req, res) => Promise.resolve(fn(req, res))
+const asyncMiddleware = (fn) => (req, res) => Promise.resolve(fn(req, res, next))
   .then((data) => respondWithSuccess(res, data))
   .catch((error) => {
     if (error instanceof RequestError) {
       res.status(error.statusCode).send(error.errorMessage);
     } else {
-      res.status(500).send('Request fallo');
+      next(error);
     }
   });
 

--- a/frontend/src/ReduxWebSocketWrapper.js
+++ b/frontend/src/ReduxWebSocketWrapper.js
@@ -57,7 +57,7 @@ export function useRuthConnectedStore(reunion) {
   const [store, setStore] = useState();
 
   useEffect(() => {
-    if (!reunion || !reunion.abierta) {
+    if (!reunion) {
       return;
     }
     const ws = new ReconnectingWebSocket(reunion.id);

--- a/frontend/src/Reunion.js
+++ b/frontend/src/Reunion.js
@@ -31,11 +31,12 @@ const Reunion = ({ usuario }) => {
   }
 
   return <>
-    <GlobalStyle/>
-    <Provider store={store}>
-        <Route exact path="/:reunionId/presentador" component={() => <TemasHandler usuario={usuario} />} />
-        <Route exact path="/:reunionId" component={() => <Mobile usuario={usuario}/>}/>
-    </Provider>
+        <GlobalStyle/>
+        <Provider store={store}>
+            <Route exact path="/:reunionId/presentador" component={() => <TemasHandler usuario={usuario}/>}/>
+            <Route exact path="/:reunionId/ver" component={() => <TemasHandler usuario={usuario}/>}/>
+            <Route exact path="/:reunionId" component={() => <Mobile usuario={usuario}/>}/>
+        </Provider>
   </>;
 };
 

--- a/frontend/src/Reunion.js
+++ b/frontend/src/Reunion.js
@@ -31,12 +31,11 @@ const Reunion = ({ usuario }) => {
   }
 
   return <>
-        <GlobalStyle/>
-        <Provider store={store}>
-            <Route exact path="/:reunionId/presentador" component={() => <TemasHandler usuario={usuario}/>}/>
-            <Route exact path="/:reunionId/ver" component={() => <TemasHandler usuario={usuario}/>}/>
-            <Route exact path="/:reunionId" component={() => <Mobile usuario={usuario}/>}/>
-        </Provider>
+    <GlobalStyle/>
+    <Provider store={store}>
+      <Route exact path="/:reunionId/presentador" component={() => <TemasHandler usuario={usuario}/>}/>
+      <Route exact path="/:reunionId" component={() => <Mobile usuario={usuario}/>}/>
+    </Provider>
   </>;
 };
 

--- a/frontend/src/api/requester.js
+++ b/frontend/src/api/requester.js
@@ -8,12 +8,10 @@ const extractResponse = (response) => response.data;
 const handleError = (error) => {
     // eslint-disable-next-line no-console
     console.error(error);
-    if (error.response){
-        toast.error(error.response.data);
-
-    }else{
+    if (!error.response.data){
         toast.error(error.message);
-
+    }else{
+        toast.error(error.response.data);
     }
     return Promise.reject(error);
 };

--- a/frontend/src/api/requester.js
+++ b/frontend/src/api/requester.js
@@ -6,10 +6,16 @@ const backendUrl = '/api';
 const extractResponse = (response) => response.data;
 
 const handleError = (error) => {
-  // eslint-disable-next-line no-console
-  console.error(error);
-  toast.error(error.message);
-  return Promise.reject(error);
+    // eslint-disable-next-line no-console
+    console.error(error);
+    if (error.response){
+        toast.error(error.response.data);
+
+    }else{
+        toast.error(error.message);
+
+    }
+    return Promise.reject(error);
 };
 
 const Requester = {

--- a/frontend/src/empezar-reunion/EmpezarReunion.js
+++ b/frontend/src/empezar-reunion/EmpezarReunion.js
@@ -53,7 +53,7 @@ class EmpezarReunion extends React.Component {
       })
       .catch(() => {
         this.setState({ cargando: false });
-        toast.error('Error al iniciar la reunión');
+
       });
   };
 

--- a/frontend/src/empezar-reunion/ReunionesCerradas.js
+++ b/frontend/src/empezar-reunion/ReunionesCerradas.js
@@ -8,8 +8,12 @@ import { StyledTableCell } from '../minuta/TablaOradores.styled';
 import { ButtonIcono, ButtonReunionCerrada, SecondaryButtonReunionCerrada } from '../components/Button.styled';
 import { Reuniones } from './Reuniones';
 
-const FilaReunion = () => <StyledTableCell>
-            <ButtonReunionCerrada>
+    const onClick = () => {
+        history.push(`/${reunion.id}/ver`);
+    }
+
+    const FilaReunion = () => <StyledTableCell>
+            <ButtonReunionCerrada onClick={onClick}>
                 Ver
             </ButtonReunionCerrada>
             <SecondaryButtonReunionCerrada>

--- a/frontend/src/empezar-reunion/ReunionesCerradas.js
+++ b/frontend/src/empezar-reunion/ReunionesCerradas.js
@@ -1,39 +1,39 @@
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
-import { faSlack } from '@fortawesome/free-brands-svg-icons';
-import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { StyledTableCell } from '../minuta/TablaOradores.styled';
-import { ButtonIcono, ButtonReunionCerrada, SecondaryButtonReunionCerrada } from '../components/Button.styled';
-import { Reuniones } from './Reuniones';
+import {faSlack} from '@fortawesome/free-brands-svg-icons';
+import {faEnvelope} from '@fortawesome/free-solid-svg-icons';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {StyledTableCell} from '../minuta/TablaOradores.styled';
+import {ButtonIcono, ButtonReunionCerrada, SecondaryButtonReunionCerrada} from '../components/Button.styled';
+import {Reuniones} from './Reuniones';
 import React from 'react';
 
 
 const FilaReunion = ({reunion, history}) => {
-    const onClick = () => {
-        history.push(`/${reunion.id}/ver`);
-    }
+  const handleClickVer = () => {
+    history.push(`/${reunion.id}/ver`);
+  }
 
- return <StyledTableCell>
-            <ButtonReunionCerrada onClick={onClick}>
-                Ver
-            </ButtonReunionCerrada>
-            <SecondaryButtonReunionCerrada>
-                Ver Minuta
-            </SecondaryButtonReunionCerrada>
-            <Tooltip title={<Typography color="inherit">Reenviar mail de minuta</Typography>}>
-                <ButtonIcono>
-                    <FontAwesomeIcon icon={faEnvelope}/>
-                </ButtonIcono>
-            </Tooltip>
-            <Tooltip title={<Typography color="inherit">Reenviar recordatorios de slack</Typography>}>
-                <ButtonIcono>
-                    <FontAwesomeIcon icon={faSlack}/>
-                </ButtonIcono>
-            </Tooltip>
-        </StyledTableCell>;
+  return <StyledTableCell>
+    <ButtonReunionCerrada onClick={handleClickVer}>
+      Ver
+    </ButtonReunionCerrada>
+    <SecondaryButtonReunionCerrada>
+      Ver Minuta
+    </SecondaryButtonReunionCerrada>
+    <Tooltip title={<Typography color="inherit">Reenviar mail de minuta</Typography>}>
+      <ButtonIcono>
+        <FontAwesomeIcon icon={faEnvelope}/>
+      </ButtonIcono>
+    </Tooltip>
+    <Tooltip title={<Typography color="inherit">Reenviar recordatorios de slack</Typography>}>
+      <ButtonIcono>
+        <FontAwesomeIcon icon={faSlack}/>
+      </ButtonIcono>
+    </Tooltip>
+  </StyledTableCell>;
 }
 
 export const ReunionesCerradas = () => <>
-        <Reuniones estaAbierta={false} columnas={['Nombre de reunion', 'Autor', 'Fecha', 'Acciones']} CallToActionButton={FilaReunion}/>
+ <Reuniones estaAbierta={false} columnas={['Nombre de reunion', 'Autor', 'Fecha', 'Acciones']} CallToActionButton={FilaReunion}/>
 </>;

--- a/frontend/src/empezar-reunion/ReunionesCerradas.js
+++ b/frontend/src/empezar-reunion/ReunionesCerradas.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import { faSlack } from '@fortawesome/free-brands-svg-icons';
@@ -7,12 +6,15 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { StyledTableCell } from '../minuta/TablaOradores.styled';
 import { ButtonIcono, ButtonReunionCerrada, SecondaryButtonReunionCerrada } from '../components/Button.styled';
 import { Reuniones } from './Reuniones';
+import React from 'react';
 
+
+const FilaReunion = ({reunion, history}) => {
     const onClick = () => {
         history.push(`/${reunion.id}/ver`);
     }
 
-    const FilaReunion = () => <StyledTableCell>
+ return <StyledTableCell>
             <ButtonReunionCerrada onClick={onClick}>
                 Ver
             </ButtonReunionCerrada>
@@ -30,7 +32,7 @@ import { Reuniones } from './Reuniones';
                 </ButtonIcono>
             </Tooltip>
         </StyledTableCell>;
-
+}
 
 export const ReunionesCerradas = () => <>
         <Reuniones estaAbierta={false} columnas={['Nombre de reunion', 'Autor', 'Fecha', 'Acciones']} CallToActionButton={FilaReunion}/>

--- a/frontend/src/empezar-reunion/ReunionesCerradas.js
+++ b/frontend/src/empezar-reunion/ReunionesCerradas.js
@@ -11,7 +11,7 @@ import React from 'react';
 
 const FilaReunion = ({reunion, history}) => {
   const handleClickVer = () => {
-    history.push(`/${reunion.id}/ver`);
+    history.push(`/${reunion.id}/presentador`);
   }
 
   return <StyledTableCell>

--- a/frontend/src/minuta/ConclusionTema.js
+++ b/frontend/src/minuta/ConclusionTema.js
@@ -4,7 +4,7 @@ import {Box} from "@material-ui/core";
 import {ThemedTextfield} from "../styles/theme";
 import {BotonCancelar, BotonEnviar} from "./ActionItemEditor.styled";
 
-export function ConclusionTema({ titulo, conclusion, onChange, onBorrar, onGuardar, estaEditandoConclusion }) {
+export function ConclusionTema({ titulo, conclusion, onChange, onBorrar, onGuardar, estaEditandoConclusion, reunionAbierta }) {
   
   return <ConclusionForm>
     <ConclusionTitle>
@@ -17,6 +17,7 @@ export function ConclusionTema({ titulo, conclusion, onChange, onBorrar, onGuard
       multiline
       rows="10"
       variant="outlined"
+      disabled={!reunionAbierta}
       onChange={onChange}
     />
 

--- a/frontend/src/minuta/ListaActionItems.js
+++ b/frontend/src/minuta/ListaActionItems.js
@@ -68,13 +68,14 @@ export const ListaActionItems = ({actionItems, onEdit, alBorrar}) => {
         <List alignItems="flex-start" className={classes.root}>
             {actionItems.slice().reverse().map((item, index) =>
               <>
-                <ActionItem 
+                <ActionItem
                   key={item.id} 
                   id={item.id}
                   descripcion={item.actionItem.descripcion} 
                   owners={item.actionItem.owners}
                   onEdit={onEdit}
                   onDelete={alBorrar}
+                  disabled={!reunionAbierta}
                 />
                 {!esElUltimoItem(index) && <Divider/>}
               </>

--- a/frontend/src/minuta/ListaActionItems.js
+++ b/frontend/src/minuta/ListaActionItems.js
@@ -3,7 +3,7 @@ import {List, ListItem, Divider, makeStyles} from '@material-ui/core';
 import {ActionItemContainer, ActionItemDescription, ListaActionItemsContainer, Owner} from './ListaActionItems.styled'
 import {ActionItemEditor} from "./ActionItemEditor";
 
-const ActionItem = ({descripcion, owners, onEdit, onDelete, id}) =>{
+const ActionItem = ({descripcion, owners, onEdit, onDelete, id, reunionAbierta}) =>{
   const [estaEditando, setEstaEditando] = useState(false);
 
   const actionItemConId = (actionItem) => { return {...actionItem, id}}
@@ -22,12 +22,13 @@ const ActionItem = ({descripcion, owners, onEdit, onDelete, id}) =>{
   };
   
   return (
-    <ListItem 
-      style={itemClass} 
+    <ListItem
+      style={itemClass}
       button={!estaEditando}
-      onClick={()=> !estaEditando? setEstaEditando(true) : null}
+      onClick={()=> !estaEditando ? setEstaEditando(true) : null}
+      disabled={!reunionAbierta}
     >
-      {!estaEditando ? 
+      {!estaEditando ?
         <ActionItemContainer>
           <ActionItemDescription>{descripcion}</ActionItemDescription>
           <div>
@@ -35,7 +36,7 @@ const ActionItem = ({descripcion, owners, onEdit, onDelete, id}) =>{
           </div>
         </ActionItemContainer>
       :
-        <ActionItemEditor 
+        <ActionItemEditor
           itemDescription={descripcion}
           itemOwners={owners}
           estaEditando={estaEditando}
@@ -48,7 +49,7 @@ const ActionItem = ({descripcion, owners, onEdit, onDelete, id}) =>{
   )
 }
 
-export const ListaActionItems = ({actionItems, onEdit, alBorrar}) => {
+export const ListaActionItems = ({actionItems, onEdit, alBorrar, reunionAbierta}) => {
   
   function esElUltimoItem(index) {
     return actionItems.length === index + 1;
@@ -75,7 +76,7 @@ export const ListaActionItems = ({actionItems, onEdit, alBorrar}) => {
                   owners={item.actionItem.owners}
                   onEdit={onEdit}
                   onDelete={alBorrar}
-                  disabled={!reunionAbierta}
+                  reunionAbierta={reunionAbierta}
                 />
                 {!esElUltimoItem(index) && <Divider/>}
               </>

--- a/frontend/src/reunion/TemasHandler.js
+++ b/frontend/src/reunion/TemasHandler.js
@@ -8,38 +8,32 @@ import { temaEventos } from '../store/tema';
 import { reunionEventos } from '../store/reunion';
 
 class TemasHandler extends React.Component {
-cerrarReunion = (temas) => {
+  cerrarReunion = (temas) => {
     if (!this.props.estadoReunion) {
-        toast.error('La reunion ya está cerrada');
+      toast.error('La reunion ya está cerrada');
     } else {
-        backend.cerrarReunion(this.props.reunionId, temas)
-            .then(() => {
-                this.props.dispatch(reunionEventos.finalizarReunionActual());
-                this.props.history.push('/');
-            })
-            .then(() => {
-                if (this.props.estadoReunion) {
-                    toast.success('Reunión finalizada');
-                } else {
-                    toast.success('Reunión cerrada');
-                }
-            })
-            .catch(() => {
-                toast.error('No se pudo finalizar la reunión');
-            });
-    }
-}
+       backend.cerrarReunion(this.props.reunionId, temas)
+         .then(() => {
+           this.props.dispatch(reunionEventos.finalizarReunionActual());
+           this.props.history.push('/');
+           toast.success('Reunión finalizada');
+         })
+         .catch(() => {
+           toast.error('No se pudo finalizar la reunión');
+          });
+      }
+  }
 
 
-    render() {
-      return <VistaTemas
-            usuario={this.props.usuario}
-            temas={this.props.temas}
-            dispatch={this.props.dispatch}
-            cerrarReunion={this.cerrarReunion}
-            estadoReunion={this.props.estadoReunion}
-        />;
-    }
+  render() {
+    return <VistaTemas
+      usuario={this.props.usuario}
+      temas={this.props.temas}
+      dispatch={this.props.dispatch}
+      cerrarReunion={this.cerrarReunion}
+      estadoReunion={this.props.estadoReunion}
+      />;
+  }
 }
 
 

--- a/frontend/src/reunion/TemasHandler.js
+++ b/frontend/src/reunion/TemasHandler.js
@@ -1,36 +1,49 @@
 import React from 'react';
 import { toast } from 'react-toastify';
 import { connect } from 'react-redux';
+import { useParams, withRouter } from 'react-router-dom';
 import backend from '../api/backend';
 import VistaTemas from './VistaTemas';
+import { temaEventos } from '../store/tema';
 import { reunionEventos } from '../store/reunion';
-import {withRouter} from "react-router-dom";
 
 class TemasHandler extends React.Component {
+    cerrarReunion = (temas) => {
+      console.log(this.props.estadoReunion);
 
-  cerrarReunion = (temas) => {
-    backend.cerrarReunion(this.props.reunionId,temas)
-      .then(() => {
-        this.props.dispatch(reunionEventos.finalizarReunionActual());
-        this.props.history.push("/");
-      })
-      .then(() => toast.success('Reunión finalizada'))
-      .catch(() => {toast.error('No se pudo finalizar la reunión')});
-  }
+      backend.cerrarReunion(this.props.reunionId, temas)
+        .then(() => {
+          this.props.dispatch(reunionEventos.finalizarReunionActual());
+          this.props.history.push('/');
+        })
+        .then(() => {
+          if (this.props.estadoReunion) {
+            toast.success('Reunión finalizada');
+          } else {
+            toast.success('Reunión cerrada');
+          }
+        })
+        .catch(() => {
+          toast.error('No se pudo finalizar la reunión');
+        });
+    }
 
-  render() {
-    return <VistaTemas
-      usuario={this.props.usuario}
-      temas={this.props.temas}
-      dispatch={this.props.dispatch}
-      cerrarReunion={this.cerrarReunion}
-    />;
-  }
+
+    render() {
+      return <VistaTemas
+            usuario={this.props.usuario}
+            temas={this.props.temas}
+            dispatch={this.props.dispatch}
+            cerrarReunion={this.cerrarReunion}
+            estadoReunion={this.props.estadoReunion}
+        />;
+    }
 }
 
 
 const mapStateToProps = (state) => ({
   temas: state.reunion.temas,
   reunionId: state.reunion.id,
+  estadoReunion: state.reunion.abierta,
 });
 export default connect(mapStateToProps)(withRouter(TemasHandler));

--- a/frontend/src/reunion/TemasHandler.js
+++ b/frontend/src/reunion/TemasHandler.js
@@ -8,24 +8,27 @@ import { temaEventos } from '../store/tema';
 import { reunionEventos } from '../store/reunion';
 
 class TemasHandler extends React.Component {
-    cerrarReunion = (temas) => {
-
-      backend.cerrarReunion(this.props.reunionId, temas)
-        .then(() => {
-          this.props.dispatch(reunionEventos.finalizarReunionActual());
-          this.props.history.push('/');
-        })
-        .then(() => {
-          if (this.props.estadoReunion) {
-            toast.success('Reunión finalizada');
-          } else {
-            toast.success('Reunión cerrada');
-          }
-        })
-        .catch(() => {
-          toast.error('No se pudo finalizar la reunión');
-        });
+cerrarReunion = (temas) => {
+    if (!this.props.estadoReunion) {
+        toast.error('La reunion ya está cerrada');
+    } else {
+        backend.cerrarReunion(this.props.reunionId, temas)
+            .then(() => {
+                this.props.dispatch(reunionEventos.finalizarReunionActual());
+                this.props.history.push('/');
+            })
+            .then(() => {
+                if (this.props.estadoReunion) {
+                    toast.success('Reunión finalizada');
+                } else {
+                    toast.success('Reunión cerrada');
+                }
+            })
+            .catch(() => {
+                toast.error('No se pudo finalizar la reunión');
+            });
     }
+}
 
 
     render() {

--- a/frontend/src/reunion/TemasHandler.js
+++ b/frontend/src/reunion/TemasHandler.js
@@ -9,7 +9,6 @@ import { reunionEventos } from '../store/reunion';
 
 class TemasHandler extends React.Component {
     cerrarReunion = (temas) => {
-      console.log(this.props.estadoReunion);
 
       backend.cerrarReunion(this.props.reunionId, temas)
         .then(() => {

--- a/frontend/src/reunion/VistaTemas.js
+++ b/frontend/src/reunion/VistaTemas.js
@@ -29,6 +29,10 @@ const VistaTemas = ({dispatch, cerrarReunion, temas, usuario, estadoReunion}) =>
   }, [indiceTemaATratar]);
 
   const empezarTema = () => {
+    if(estadoReunion === false){
+      toast.error('Esta reunion está cerrada, no se puede abrir un tema');
+      return;
+    }
     if (temaSeleccionado.inicio !== null) {
       toast.error('No se puede iniciar un tema que ya fue iniciado');
       return 

--- a/frontend/src/reunion/VistaTemas.js
+++ b/frontend/src/reunion/VistaTemas.js
@@ -29,7 +29,7 @@ const VistaTemas = ({dispatch, cerrarReunion, temas, usuario, estadoReunion}) =>
   }, [indiceTemaATratar]);
 
   const empezarTema = () => {
-    if(estadoReunion === false){
+    if(!estadoReunion){
       toast.error('Esta reunion está cerrada, no se puede abrir un tema');
       return;
     }
@@ -59,7 +59,7 @@ const VistaTemas = ({dispatch, cerrarReunion, temas, usuario, estadoReunion}) =>
 
   const reabrirTema = () => {
     if(estadoReunion === false){
-      toast.error('Esta reunion está cerrada, no se puede abrir un tema');
+      toast.error('Esta reunion está cerrada, no se puede reabrir un tema');
       return;
     }
     if(existeUnTemaEmpezado()){

--- a/frontend/src/reunion/VistaTemas.js
+++ b/frontend/src/reunion/VistaTemas.js
@@ -13,7 +13,7 @@ import Mobile from '../mobile/index';
 import { temaEventos } from '../store/tema';
 
 
-const VistaTemas = ({dispatch, cerrarReunion, temas, usuario, estadoReunion}) => {
+const VistaTemas = ({dispatch, cerrarReunion, temas, usuario, estadoReunion: reunionAbierta}) => {
 
   const indiceTemaSinFinalizar = temas.findIndex((tema) => tema.fin === null);
   const ultimoTema = temas.length - 1;
@@ -29,13 +29,13 @@ const VistaTemas = ({dispatch, cerrarReunion, temas, usuario, estadoReunion}) =>
   }, [indiceTemaATratar]);
 
   const empezarTema = () => {
-    if(!estadoReunion){
+    if(!reunionAbierta){
       toast.error('Esta reunion está cerrada, no se puede abrir un tema');
       return;
     }
     if (temaSeleccionado.inicio !== null) {
       toast.error('No se puede iniciar un tema que ya fue iniciado');
-      return 
+      return
     }
     if(existeUnTemaEmpezado()){
       toast.error('Ya hay otro tema en curso');
@@ -50,7 +50,7 @@ const VistaTemas = ({dispatch, cerrarReunion, temas, usuario, estadoReunion}) =>
 
   const estaElTemaEmpezado = (tema) => {
    return tema.inicio && !tema.fin;
-  } 
+  }
 
   const terminarTema = () => {
     dispatch(temaEventos.terminarTema(temaSeleccionado.id))
@@ -58,7 +58,7 @@ const VistaTemas = ({dispatch, cerrarReunion, temas, usuario, estadoReunion}) =>
   };
 
   const reabrirTema = () => {
-    if(estadoReunion === false){
+    if(!reunionAbierta){
       toast.error('Esta reunion está cerrada, no se puede reabrir un tema');
       return;
     }
@@ -125,7 +125,8 @@ const VistaTemas = ({dispatch, cerrarReunion, temas, usuario, estadoReunion}) =>
                            temaActivo={temaActivo()}
                            avanzarTema={avanzarTema}
                            retrocederTema={retrocederTema}
-                           handleCerrarReunion={handleCerrarReunion}/>
+                           handleCerrarReunion={handleCerrarReunion}
+                           reunionAbierta={reunionAbierta}/>
       </VistaTemaContainer>
       <Sidebar handleSelection={setSelectedElement}
                selectedElement={selectedElement}

--- a/frontend/src/reunion/VistaTemas.js
+++ b/frontend/src/reunion/VistaTemas.js
@@ -110,6 +110,7 @@ const VistaTemas = ({dispatch, cerrarReunion, temas, usuario, estadoReunion: reu
                seleccionarTema={seleccionarTema}
                cerrarReunion={handleCerrarReunion}
                temaActual={temaSeleccionado}
+               reunionAbierta={reunionAbierta}
       />
 
       {(selectedElement !== 'Opinar' &&

--- a/frontend/src/reunion/VistaTemas.js
+++ b/frontend/src/reunion/VistaTemas.js
@@ -13,7 +13,7 @@ import Mobile from '../mobile/index';
 import { temaEventos } from '../store/tema';
 
 
-const VistaTemas = ({dispatch, cerrarReunion, temas, usuario}) => {
+const VistaTemas = ({dispatch, cerrarReunion, temas, usuario, estadoReunion}) => {
 
   const indiceTemaSinFinalizar = temas.findIndex((tema) => tema.fin === null);
   const ultimoTema = temas.length - 1;
@@ -54,6 +54,10 @@ const VistaTemas = ({dispatch, cerrarReunion, temas, usuario}) => {
   };
 
   const reabrirTema = () => {
+    if(estadoReunion === false){
+      toast.error('Esta reunion está cerrada, no se puede abrir un tema');
+      return;
+    }
     if(existeUnTemaEmpezado()){
       toast.error('Ya hay otro tema en curso');
       return

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -117,13 +117,13 @@ const wsForwarder = (store) => (next) => (action) => {
 };
 
 const reunionAbiertaCheckMiddleware = (store) => (next) => (action) => {
-  let state = store.getState();
-  if(!state.reunion || state.reunion.abierta){
-    next(action)
-  }else{
-    toast.error('La reunion ya fue finalizada')
+  const state = store.getState();
+  if (!state.reunion || state.reunion.abierta || !state.reunion.abierta) {
+    next(action);
+  } else {
+    toast.error('La reunion ya fue finalizada');
   }
-}
+};
 
 export default () =>
   configureStore({

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -116,17 +116,8 @@ const wsForwarder = (store) => (next) => (action) => {
   }
 };
 
-const reunionAbiertaCheckMiddleware = (store) => (next) => (action) => {
-  const state = store.getState();
-  if (!state.reunion || state.reunion.abierta || !state.reunion.abierta) {
-    next(action);
-  } else {
-    toast.error('La reunion ya fue finalizada');
-  }
-};
-
 export default () =>
   configureStore({
     reducer: stateReducer,
-    middleware: [...getDefaultMiddleware(), reunionAbiertaCheckMiddleware, wsForwarder],
+    middleware: [...getDefaultMiddleware(), wsForwarder],
   });

--- a/frontend/src/store/reunion.js
+++ b/frontend/src/store/reunion.js
@@ -26,6 +26,7 @@ export const reunionReducer = (state, action) =>
     switch (action.type) {
       case reunionEventoTypes.EMPEZAR_REUNION: {
         draft.reunion = action.reunion;
+        draft.reunion.abierta = true;
         draft.reunion.temas = action.reunion.temas
           .map((tema) => temaReducer(tema, action))
           .sort(compareTema);
@@ -52,7 +53,9 @@ export const reunionReducer = (state, action) =>
           );
           break;
         }
-
+        if (!draft.reunion.abierta) {
+          break;
+        }
         draft.reunion.temas[temaIndex] = temaReducer(
             draft.reunion.temas[temaIndex],
             action

--- a/frontend/src/store/reunion.js
+++ b/frontend/src/store/reunion.js
@@ -1,6 +1,6 @@
 import produce from "immer";
-import { createEvent } from "./evento";
-import { temaReducer } from "./tema";
+import {createEvent} from "./evento";
+import {temaReducer} from "./tema";
 
 export const reunionEventoTypes = {
   EMPEZAR_REUNION: "Una reunion es comenzada",
@@ -13,11 +13,11 @@ export const reunionEventos = {
   comenzarReunion: (reunion) =>
     createEvent(reunionEventoTypes.EMPEZAR_REUNION, {
       reunion,
-      comesFromWS:true
+      comesFromWS: true
     }),
-  finalizarReunionActual: () => 
+  finalizarReunionActual: () =>
     createEvent(reunionEventoTypes.TERMINAR_REUNION),
-  
+
 };
 
 export const reunionReducer = (state, action) =>
@@ -25,8 +25,7 @@ export const reunionReducer = (state, action) =>
     draft.ultimoEventoId = action.id;
     switch (action.type) {
       case reunionEventoTypes.EMPEZAR_REUNION: {
-        draft.reunion = action.reunion;
-        draft.reunion.abierta = true;
+        draft.reunion = {...action.reunion, abierta: true}
         draft.reunion.temas = action.reunion.temas
           .map((tema) => temaReducer(tema, action))
           .sort(compareTema);
@@ -36,17 +35,17 @@ export const reunionReducer = (state, action) =>
         draft.reunion.abierta = false;
         break;
       }
-      
-      default:{
+
+      default: {
         if (!draft.reunion?.temas) {
           break;
         }
-        
+
         const temaIndex = draft.reunion.temas.findIndex(
           (tema) => tema.id === action.idTema
         );
 
-        if (temaIndex === -1){
+        if (temaIndex === -1) {
           console.error(
             "Se recibio una accion con un idTema desconocido",
             action
@@ -57,10 +56,10 @@ export const reunionReducer = (state, action) =>
           break;
         }
         draft.reunion.temas[temaIndex] = temaReducer(
-            draft.reunion.temas[temaIndex],
-            action
-          );
-          break;
+          draft.reunion.temas[temaIndex],
+          action
+        );
+        break;
       }
     }
   });

--- a/frontend/src/styles/CustomTooltip.js
+++ b/frontend/src/styles/CustomTooltip.js
@@ -1,0 +1,16 @@
+import Tooltip from "@material-ui/core/Tooltip";
+import Typography from "@material-ui/core/Typography";
+import React from "react";
+
+const CustomTooltip = ({children, disable, title}) => {
+    return <Tooltip title={<Typography color="inherit">{title}</Typography>}
+                    disableFocusListener
+                    disableTouchListener
+                    open={disable ? undefined : false}>
+        <span>
+            {children}
+         </span>
+    </Tooltip>
+}
+
+export default CustomTooltip

--- a/frontend/src/temario/Temario.js
+++ b/frontend/src/temario/Temario.js
@@ -28,7 +28,8 @@ class Temario extends React.Component {
                         seleccionarTema = {this.props.seleccionarTema}/>
           <SecondaryButton style={{ marginBottom: '2rem', marginTop: 'auto', padding: '0.5em 0',  height: '3em' }}
                            onClick={this.props.cerrarReunion}
-                           disabled={false}>Cerrar Reunión</SecondaryButton>
+                           disabled={!this.props.reunionAbierta}
+                           >Cerrar Reunión</SecondaryButton>
         </ContenidoTemario>
         <Arrow src="/pino-blanco.svg"
                onMouseEnter={() => this.setState({ isActive: true })} />

--- a/frontend/src/tipos-vista-principal/Minuta.js
+++ b/frontend/src/tipos-vista-principal/Minuta.js
@@ -26,7 +26,7 @@ const expositor = (nombreOrador, ordenDeOrador, resumen) => {
   }
 }
 
-const Minuta = ({ dispatch, tema }) => {
+const Minuta = ({ dispatch, tema, reunionAbierta }) => {
   let [conclusion, setConclusion] = useState(tema.conclusion);
   let [estaEditandoConclusion, setEstaEditandoConclusion] = useState(false);
   let [exposicionSeleccionada, setExposicionSeleccionada] = useState(null);
@@ -144,6 +144,7 @@ const Minuta = ({ dispatch, tema }) => {
           <BotonParaAbrirDesplegable
             variant="outlined"
             endIcon={<FontAwesomeIcon icon={faChevronDown}/>}
+            disabled={!reunionAbierta}
             onClick={() => setIsResumenOradorCerrado(!isResumenOradorCerrado)}
           >
             {textoBotonEdicion()}
@@ -168,6 +169,7 @@ const Minuta = ({ dispatch, tema }) => {
               <ConclusionTema
                 titulo={"Resumen General"}
                 conclusion={conclusion}
+                reunionAbierta={reunionAbierta}
                 onChange={(event) => {
                   handleCambioInputConclusion(event.target.value);
                 }}
@@ -181,6 +183,7 @@ const Minuta = ({ dispatch, tema }) => {
               <BotonParaAbrirDesplegable
                 variant="outlined"
                 endIcon={<FontAwesomeIcon icon={faChevronDown}/>}
+                disabled={!reunionAbierta}
                 onClick={() => setIsCreadorActionItemCerrado(!isCreadorActionItemCerrado)}
               >
               {textoBotonCreadorActionItems()}

--- a/frontend/src/tipos-vista-principal/Minuta.js
+++ b/frontend/src/tipos-vista-principal/Minuta.js
@@ -17,6 +17,7 @@ import {ListaActionItems} from "../minuta/ListaActionItems"
 import {ConclusionTema} from "../minuta/ConclusionTema";
 import Grid from "@material-ui/core/Grid";
 import Box from "@material-ui/core/Box";
+import CustomTooltip from "../styles/CustomTooltip";
 
 const expositor = (nombreOrador, ordenDeOrador, resumen) => {
   return {
@@ -141,14 +142,16 @@ const Minuta = ({ dispatch, tema, reunionAbierta }) => {
           value={tabValue}
           index={0}
         >
-          <BotonParaAbrirDesplegable
-            variant="outlined"
-            endIcon={<FontAwesomeIcon icon={faChevronDown}/>}
-            disabled={!reunionAbierta}
-            onClick={() => setIsResumenOradorCerrado(!isResumenOradorCerrado)}
-          >
-            {textoBotonEdicion()}
-          </BotonParaAbrirDesplegable>
+          <CustomTooltip title='La reunion esta cerrada' disable={!reunionAbierta}>
+            <BotonParaAbrirDesplegable
+              variant="outlined"
+              endIcon={<FontAwesomeIcon icon={faChevronDown}/>}
+              disabled={!reunionAbierta}
+              onClick={() => setIsResumenOradorCerrado(!isResumenOradorCerrado)}
+            >
+              {textoBotonEdicion()}
+            </BotonParaAbrirDesplegable>
+          </CustomTooltip>
           <Collapse in={isResumenOradorCerrado}>
             <Box
               display={"flex"}
@@ -180,14 +183,16 @@ const Minuta = ({ dispatch, tema, reunionAbierta }) => {
             </Grid>
             <Grid item xs={7}>
               <h1>Action Items ({tema.actionItems.length})</h1>
-              <BotonParaAbrirDesplegable
-                variant="outlined"
-                endIcon={<FontAwesomeIcon icon={faChevronDown}/>}
-                disabled={!reunionAbierta}
-                onClick={() => setIsCreadorActionItemCerrado(!isCreadorActionItemCerrado)}
-              >
-              {textoBotonCreadorActionItems()}
-              </BotonParaAbrirDesplegable>
+              <CustomTooltip title='La reunion esta cerrada' disable={!reunionAbierta}>
+                <BotonParaAbrirDesplegable
+                  variant="outlined"
+                  endIcon={<FontAwesomeIcon icon={faChevronDown}/>}
+                  disabled={!reunionAbierta}
+                  onClick={() => setIsCreadorActionItemCerrado(!isCreadorActionItemCerrado)}
+                >
+                {textoBotonCreadorActionItems()}
+                </BotonParaAbrirDesplegable>
+              </CustomTooltip>
               <Collapse in={isCreadorActionItemCerrado}>
                 <Box
                   display={"flex"}

--- a/frontend/src/tipos-vista-principal/Minuta.js
+++ b/frontend/src/tipos-vista-principal/Minuta.js
@@ -202,7 +202,7 @@ const Minuta = ({ dispatch, tema, reunionAbierta }) => {
                   <ActionItemEditor onSubmit={agregarActionItem}/>
                 </Box>
               </Collapse>
-              <ListaActionItems actionItems={tema.actionItems} alBorrar={borrarActionItem} onEdit={editarActionItem} />
+              <ListaActionItems actionItems={tema.actionItems} alBorrar={borrarActionItem} onEdit={editarActionItem} reunionAbierta={reunionAbierta}/>
             </Grid>
           </Grid>
         </TabRenderer>

--- a/frontend/src/tipos-vista-principal/Minuta.js
+++ b/frontend/src/tipos-vista-principal/Minuta.js
@@ -142,7 +142,7 @@ const Minuta = ({ dispatch, tema, reunionAbierta }) => {
           value={tabValue}
           index={0}
         >
-          <CustomTooltip title='La reunion esta cerrada' disable={!reunionAbierta}>
+          <CustomTooltip title='La reunion está cerrada' disable={!reunionAbierta}>
             <BotonParaAbrirDesplegable
               variant="outlined"
               endIcon={<FontAwesomeIcon icon={faChevronDown}/>}
@@ -183,7 +183,7 @@ const Minuta = ({ dispatch, tema, reunionAbierta }) => {
             </Grid>
             <Grid item xs={7}>
               <h1>Action Items ({tema.actionItems.length})</h1>
-              <CustomTooltip title='La reunion esta cerrada' disable={!reunionAbierta}>
+              <CustomTooltip title='La reunion está cerrada' disable={!reunionAbierta}>
                 <BotonParaAbrirDesplegable
                   variant="outlined"
                   endIcon={<FontAwesomeIcon icon={faChevronDown}/>}

--- a/frontend/src/tipos-vista-principal/Resumen.js
+++ b/frontend/src/tipos-vista-principal/Resumen.js
@@ -36,13 +36,13 @@ const Resumen = ({ tema, retrocederTema, empezarTema, avanzarTema, temaActivo, t
             cursor={'pointer'}
             onClick={retrocederTema}/>
             {!tema.inicio &&
-              <CustomTooltip title='Reunion cerrada' disable={!reunionAbierta}>
+              <CustomTooltip title='La reunion está cerrada' disable={!reunionAbierta}>
                 <Button onClick={empezarTema} disabled={!reunionAbierta} style={!reunionAbierta ? {pointerEvents: "none"} : {}}>Empezar Tema</Button>
               </CustomTooltip>
             }
             {tema.inicio &&
               <Zoom in style={{transitionDelay: '100ms'}}>
-                <CustomTooltip title='Reunion cerrada' disable={!reunionAbierta}>
+                <CustomTooltip title='La reunion está cerrada' disable={!reunionAbierta}>
                   <SecondaryButton onClick={() => temaActivo ? setOpen(true) : reabrirTema()}
                                    disabled={!reunionAbierta}
                                    style={!reunionAbierta ? {pointerEvents: "none"} : {}}>

--- a/frontend/src/tipos-vista-principal/Resumen.js
+++ b/frontend/src/tipos-vista-principal/Resumen.js
@@ -17,7 +17,7 @@ const tiposDeTema = {
   'proponerPinos': DescripcionPropuestaPinos,
 };
 
-const Resumen = ({tema, retrocederTema, empezarTema, avanzarTema, temaActivo, terminarTema, reabrirTema}) => {
+const Resumen = ({tema, retrocederTema, empezarTema, avanzarTema, temaActivo, terminarTema, reabrirTema, reunionAbierta}) => {
   const props = useSpring({opacity: 1, from: {opacity: 0}});
   const DescripcionDelTema = tiposDeTema[tema.tipo];
   const [open, setOpen] = useState(false);
@@ -34,10 +34,10 @@ const Resumen = ({tema, retrocederTema, empezarTema, avanzarTema, temaActivo, te
             cursor={'pointer'}
             onClick={retrocederTema}/>
           {!tema.inicio &&
-          <Button onClick={empezarTema}>Empezar Tema</Button>}
+          <Button onClick={empezarTema} disabled={!reunionAbierta}>Empezar Tema</Button>}
           {tema.inicio &&
           <Zoom in style={{transitionDelay: '100ms'}}>
-            <SecondaryButton onClick={() => temaActivo ? setOpen(true) : reabrirTema()}>
+            <SecondaryButton onClick={() => temaActivo ? setOpen(true) : reabrirTema()} disabled={!reunionAbierta}>
               { temaActivo ? 'Terminar Tema' : 'Reabrir tema' }
             </SecondaryButton>
           </Zoom>

--- a/frontend/src/tipos-vista-principal/Resumen.js
+++ b/frontend/src/tipos-vista-principal/Resumen.js
@@ -10,48 +10,70 @@ import DescripcionActionItems from "../temario/descripcion-tipo-tema/Descripcion
 import DescripcionPropuestaPinos from "../temario/descripcion-tipo-tema/DescripcionPropuestaPinos";
 import {ModalDeConfirmacion} from "./Modal";
 import Zoom from "@material-ui/core/Zoom";
+import CustomTooltip from "../styles/CustomTooltip";
 
 const tiposDeTema = {
-  'conDescripcion': DescripcionTemaComun,
-  'repasarActionItems': DescripcionActionItems,
-  'proponerPinos': DescripcionPropuestaPinos,
+    'conDescripcion': DescripcionTemaComun,
+    'repasarActionItems': DescripcionActionItems,
+    'proponerPinos': DescripcionPropuestaPinos,
 };
 
-const Resumen = ({tema, retrocederTema, empezarTema, avanzarTema, temaActivo, terminarTema, reabrirTema, reunionAbierta}) => {
-  const props = useSpring({opacity: 1, from: {opacity: 0}});
-  const DescripcionDelTema = tiposDeTema[tema.tipo];
-  const [open, setOpen] = useState(false);
 
-  return (
-    <VistaDelMedioContainer style={props}>
-      <DescripcionDelTema tema={tema}/>
-      <InfoTema tema={tema}/>
-      <Botonera>
-        <BotoneraNavegacionTemas>
-          <FontAwesomeIcon
-            icon={faCaretLeft}
-            size="4x"
-            cursor={'pointer'}
-            onClick={retrocederTema}/>
-          {!tema.inicio &&
-          <Button onClick={empezarTema} disabled={!reunionAbierta}>Empezar Tema</Button>}
-          {tema.inicio &&
-          <Zoom in style={{transitionDelay: '100ms'}}>
-            <SecondaryButton onClick={() => temaActivo ? setOpen(true) : reabrirTema()} disabled={!reunionAbierta}>
-              { temaActivo ? 'Terminar Tema' : 'Reabrir tema' }
-            </SecondaryButton>
-          </Zoom>
-          }
-          <ModalDeConfirmacion title={"Terminar Tema"} open={open} onClose={() => setOpen(false)} onConfirm={terminarTema}/>
+const Resumen = ({
+                     tema,
+                     retrocederTema,
+                     empezarTema,
+                     avanzarTema,
+                     temaActivo,
+                     terminarTema,
+                     reabrirTema,
+                     reunionAbierta
+                 }) => {
+    const props = useSpring({opacity: 1, from: {opacity: 0}});
+    const DescripcionDelTema = tiposDeTema[tema.tipo];
+    const [open, setOpen] = useState(false);
 
-          <FontAwesomeIcon
-            icon={faCaretRight}
-            size="4x"
-            onClick={avanzarTema}
-            cursor={'pointer'}/>
-        </BotoneraNavegacionTemas>
-      </Botonera>
-    </VistaDelMedioContainer>
-  );
+    return (
+        <VistaDelMedioContainer style={props}>
+            <DescripcionDelTema tema={tema}/>
+            <InfoTema tema={tema}/>
+            <Botonera>
+                <BotoneraNavegacionTemas>
+                    <FontAwesomeIcon
+                        icon={faCaretLeft}
+                        size="4x"
+                        cursor={'pointer'}
+                        onClick={retrocederTema}/>
+                    {!tema.inicio &&
+                    <CustomTooltip title='Reunion cerrada' disable={!reunionAbierta}>
+                        <Button onClick={empezarTema} disabled={!reunionAbierta}
+                                style={!reunionAbierta ? {pointerEvents: "none"} : {}}>Empezar Tema</Button>
+                    </CustomTooltip>
+                    }
+
+                    {tema.inicio &&
+                    <Zoom in style={{transitionDelay: '100ms'}}>
+                        <CustomTooltip title='Reunion cerrada' disable={!reunionAbierta}>
+                            <SecondaryButton onClick={() => temaActivo ? setOpen(true) : reabrirTema()}
+                                             disabled={!reunionAbierta}
+                                             style={!reunionAbierta ? {pointerEvents: "none"} : {}}>
+                                {temaActivo ? 'Terminar Tema' : 'Reabrir tema'}
+                            </SecondaryButton>
+                        </CustomTooltip>
+
+                    </Zoom>
+                    }
+                    <ModalDeConfirmacion title={"Terminar Tema"} open={open} onClose={() => setOpen(false)}
+                                         onConfirm={terminarTema}/>
+
+                    <FontAwesomeIcon
+                        icon={faCaretRight}
+                        size="4x"
+                        onClick={avanzarTema}
+                        cursor={'pointer'}/>
+                </BotoneraNavegacionTemas>
+            </Botonera>
+        </VistaDelMedioContainer>
+    );
 };
 export default Resumen;

--- a/frontend/src/tipos-vista-principal/Resumen.js
+++ b/frontend/src/tipos-vista-principal/Resumen.js
@@ -19,61 +19,45 @@ const tiposDeTema = {
 };
 
 
-const Resumen = ({
-                     tema,
-                     retrocederTema,
-                     empezarTema,
-                     avanzarTema,
-                     temaActivo,
-                     terminarTema,
-                     reabrirTema,
-                     reunionAbierta
-                 }) => {
-    const props = useSpring({opacity: 1, from: {opacity: 0}});
-    const DescripcionDelTema = tiposDeTema[tema.tipo];
-    const [open, setOpen] = useState(false);
+const Resumen = ({ tema, retrocederTema, empezarTema, avanzarTema, temaActivo, terminarTema, reabrirTema, reunionAbierta }) => {
+  const props = useSpring({opacity: 1, from: {opacity: 0}});
+  const DescripcionDelTema = tiposDeTema[tema.tipo];
+  const [open, setOpen] = useState(false);
 
-    return (
-        <VistaDelMedioContainer style={props}>
-            <DescripcionDelTema tema={tema}/>
-            <InfoTema tema={tema}/>
-            <Botonera>
-                <BotoneraNavegacionTemas>
-                    <FontAwesomeIcon
-                        icon={faCaretLeft}
-                        size="4x"
-                        cursor={'pointer'}
-                        onClick={retrocederTema}/>
-                    {!tema.inicio &&
-                    <CustomTooltip title='Reunion cerrada' disable={!reunionAbierta}>
-                        <Button onClick={empezarTema} disabled={!reunionAbierta}
-                                style={!reunionAbierta ? {pointerEvents: "none"} : {}}>Empezar Tema</Button>
-                    </CustomTooltip>
-                    }
+  return (
+    <VistaDelMedioContainer style={props}>
+      <DescripcionDelTema tema={tema}/>
+      <InfoTema tema={tema}/>
+      <Botonera>
+        <BotoneraNavegacionTemas>
+          <FontAwesomeIcon
+            icon={faCaretLeft}
+            size="4x"
+            cursor={'pointer'}
+            onClick={retrocederTema}/>
+            {!tema.inicio &&
+              <CustomTooltip title='Reunion cerrada' disable={!reunionAbierta}>
+                <Button onClick={empezarTema} disabled={!reunionAbierta} style={!reunionAbierta ? {pointerEvents: "none"} : {}}>Empezar Tema</Button>
+              </CustomTooltip>
+            }
+            {tema.inicio &&
+              <Zoom in style={{transitionDelay: '100ms'}}>
+                <CustomTooltip title='Reunion cerrada' disable={!reunionAbierta}>
+                  <SecondaryButton onClick={() => temaActivo ? setOpen(true) : reabrirTema()}
+                                   disabled={!reunionAbierta}
+                                   style={!reunionAbierta ? {pointerEvents: "none"} : {}}>
+                            {temaActivo ? 'Terminar Tema' : 'Reabrir tema'}
+                  </SecondaryButton>
+                </CustomTooltip>
 
-                    {tema.inicio &&
-                    <Zoom in style={{transitionDelay: '100ms'}}>
-                        <CustomTooltip title='Reunion cerrada' disable={!reunionAbierta}>
-                            <SecondaryButton onClick={() => temaActivo ? setOpen(true) : reabrirTema()}
-                                             disabled={!reunionAbierta}
-                                             style={!reunionAbierta ? {pointerEvents: "none"} : {}}>
-                                {temaActivo ? 'Terminar Tema' : 'Reabrir tema'}
-                            </SecondaryButton>
-                        </CustomTooltip>
-
-                    </Zoom>
-                    }
-                    <ModalDeConfirmacion title={"Terminar Tema"} open={open} onClose={() => setOpen(false)}
-                                         onConfirm={terminarTema}/>
-
-                    <FontAwesomeIcon
-                        icon={faCaretRight}
-                        size="4x"
-                        onClick={avanzarTema}
-                        cursor={'pointer'}/>
-                </BotoneraNavegacionTemas>
-            </Botonera>
-        </VistaDelMedioContainer>
+              </Zoom>
+            }
+            <ModalDeConfirmacion title={"Terminar Tema"} open={open} onClose={() => setOpen(false)}
+                                     onConfirm={terminarTema}/>
+            <FontAwesomeIcon icon={faCaretRight} size="4x" onClick={avanzarTema} cursor={'pointer'}/>
+        </BotoneraNavegacionTemas>
+      </Botonera>
+    </VistaDelMedioContainer>
     );
 };
 export default Resumen;


### PR DESCRIPTION
[**Link al Trello**](https://trello.com/c/etIcPSIb)

**Aceptación**
Conecta el botón para ver las reuniones cerradas. Bloquea los botones de empezar/rebrir tema, editar minutas y action items, y cerrar reunion si la reunión ya está cerrada. Agrega un tooltip para especificar que los botones están deshabilitados porque la reunión está cerrada. Agrega validaciones para que no se puedan publicar eventos a una reunión que ya está cerrada.

**Checklist**:
- [X] Agregue tests (y los corrí localmente)
- [X] Vi que localmente funcionara
- [x] Probe que en la review app funcionara

